### PR TITLE
Implement built-in for OPTIONS request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ coverage
 .nyc_output
 npm-debug.log
 es/
+.vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
+### v1.1.0 [Not Released]
+
+ **Warning:** Breaking change (technically)
+
+ * Renamed internal .options (per resource/router) to .config (see #10)
+ * Added built-in for `OPTIONS` request: `Resource.options` (see #10)
+
 ### v1.0.0
 
 **v1.0.0 introduces breaking changes**
@@ -35,11 +42,11 @@
 
 2. Global configuration was removed
 
-   Instead of using `setConfig` and `getConfig` one must set options per Resource<sup>1</sup>
+   Instead of using `setConfig` and `getConfig` one must set config per Resource<sup>1</sup>
 
    [1] To keep things DRY use `Router` for defining your configuration. Note: It's also possible to extend `Resource` which can be a better alternative in some cases.
 
-3. Configuration options have changed:
+3. Configuration parameters have changed:
 
    - `API_BASE` is now `apiRoot`
    - `getExtraHeaders` is now `headers`
@@ -63,7 +70,7 @@
 
    old: `new Resource(apiEndpoint, expectedStatus, mutateResponse, errorStatus)`
 
-   new: `new Resource(apiEndpoint, options)`
+   new: `new Resource(apiEndpoint, config)`
 
 ### v0.3.3
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Construct a new resource for loading data from a single (or dynamic) endpoint
 #### Arguments
 
 1. `apiEndpoint` *(string)*: Endpoint used for this resource. Supports ES6 token syntax, e.g: "/foo/bar/${pk}"
-2. `options` *(Object)*: Object containing options for this resource. see [Configuration](#configuration)
+2. `config` *(Object)*: Object containing config for this resource. see [Configuration](#configuration)
 
 #### Tokenized endpoints
 
@@ -165,6 +165,7 @@ Do a get request to the resource endpoint with optional kwargs and query paramet
 
 1. `kwargs={}` *(Object)*: Object containing the replacement values if the resource uses tokenized urls
 2. `query={}` *(Object|string)*: Query parameters to use when doing the request.
+3. `method='get'` *(string)*: Lowercase name of the HTTP method that will be used for this request.
 
 #### Returns
 
@@ -233,7 +234,7 @@ Error class used when unexpected response code occurs
 
 ### ``ValidationError``
 
-Error class used when backend response code is in ``options.statusValidationError``.
+Error class used when backend response code is in ``config.statusValidationError``.
 
 #### Extends ``InvalidResponseCode`` and overwrites:
 

--- a/src/errors.js
+++ b/src/errors.js
@@ -51,7 +51,7 @@ export class InvalidResponseCode extends BaseResourceError {
 
 
 export class ValidationError extends InvalidResponseCode {
-    constructor(err, options = null, isPrepared = false) {
+    constructor(err, config = null, isPrepared = false) {
         if (isPrepared) {
             err = {
                 responseText: err,
@@ -66,7 +66,7 @@ export class ValidationError extends InvalidResponseCode {
 
         super(err.statusCode, err.responseText, 'ValidationError');
 
-        this._customOptions = options || {};
+        this._customConfig = config || {};
         this.errors = {};
         this.nonFieldErrors = null;
 
@@ -111,11 +111,11 @@ export class ValidationError extends InvalidResponseCode {
     }
 
     __prepareError(err) {
-        return ((this._customOptions ? this._customOptions.prepareError : null) || ValidationError.defaultPrepareError)(err, this);
+        return ((this._customConfig ? this._customConfig.prepareError : null) || ValidationError.defaultPrepareError)(err, this);
     }
 
     __parseErrors(errorText) {
-        const handler = (this._customOptions ? this._customOptions.parseErrors : null) || ValidationError.defaultParseErrors;
+        const handler = (this._customConfig ? this._customConfig.parseErrors : null) || ValidationError.defaultParseErrors;
         const result = handler(errorText, this);
 
         this.nonFieldErrors = result[0];
@@ -159,7 +159,7 @@ export class ValidationError extends InvalidResponseCode {
 
         else if (isObject(err)) {
             // Note: We clone the object just in case
-            return new ValidationError(Object.assign({}, err), instance ? instance._customOptions : null, true);
+            return new ValidationError(Object.assign({}, err), instance ? instance._customConfig : null, true);
         }
 
         else {

--- a/src/router.js
+++ b/src/router.js
@@ -1,11 +1,11 @@
 import DEFAULTS from './constants';
-import { bindResources, mergeOptions } from './util';
+import { bindResources, mergeConfig } from './util';
 
 
 class Router {
-    constructor(routes, options) {
-        // Set options
-        this._customOptions = options;
+    constructor(routes, config) {
+        // Set config
+        this._customConfig = config;
 
         // set parent to null
         this._parent = null;
@@ -37,20 +37,20 @@ class Router {
     }
 
     get isBound() {
-        return !!this._parent || !!this._options;
+        return !!this._parent || !!this._config;
     }
 
-    get options() {
-        if (!this._options) {
-            this._options = mergeOptions(
+    get config() {
+        if (!this._config) {
+            this._config = mergeConfig(
                 DEFAULTS,
-                this._parent ? this._parent.options : null,
-                this.defaultOptions || this.constructor.defaultOptions || null,
-                this._customOptions,
+                this._parent ? this._parent.config : null,
+                this.defaultConfig || this.constructor.defaultConfig || null,
+                this._customConfig,
             );
         }
 
-        return this._options;
+        return this._config;
     }
 }
 

--- a/src/single.js
+++ b/src/single.js
@@ -1,6 +1,5 @@
 export default function makeSingle(baseClass) {
     class SingleObjectResource extends baseClass {
-
         fetch(kwargs, query, method = 'get') {
             const thePath = this.buildThePath(kwargs);
             return this.handleRequest(this.createRequest(method, thePath, query));
@@ -8,6 +7,10 @@ export default function makeSingle(baseClass) {
 
         head(kwargs, query) {
             return this.fetch(kwargs, query, 'head');
+        }
+
+        options(kwargs, query) {
+            return this.fetch(kwargs, query, 'options');
         }
 
         post(kwargs, data, query, method = 'post') {

--- a/src/util.js
+++ b/src/util.js
@@ -48,10 +48,10 @@ export function bindResources(routes, $this) {
     }
 }
 
-export function mergeOptions(...options) {
+export function mergeConfig(...config) {
     const res = {};
 
-    options.filter(x => !!x).forEach(opts => Object.assign(res, opts));
+    config.filter(x => !!x).forEach(opts => Object.assign(res, opts));
 
     if (!isArray(res.statusSuccess) && hasValue(res.statusSuccess)) {
         res.statusSuccess = [res.statusSuccess];

--- a/test/mergeOptions.js
+++ b/test/mergeOptions.js
@@ -1,12 +1,12 @@
 import { expect } from 'chai';
 
-import { mergeOptions } from '../src/util';
+import { mergeConfig } from '../src/util';
 
 
 export default {
-    'mergeOptions api': {
+    'mergeConfig api': {
         'assigns values': () => {
-            expect(mergeOptions(
+            expect(mergeConfig(
                 { foo: 1 },
                 { bar: 1 },
                 { baz: 1 },
@@ -17,21 +17,21 @@ export default {
             });
         },
         'statusSuccess is converted to an array': () => {
-            expect(mergeOptions(
+            expect(mergeConfig(
                 { statusSuccess: 200 },
             )).to.deep.equal({
                 statusSuccess: [200],
             });
         },
         'statusValidationError is converted to an array': () => {
-            expect(mergeOptions(
+            expect(mergeConfig(
                 { statusValidationError: 400 },
             )).to.deep.equal({
                 statusValidationError: [400],
             });
         },
         'overwrite order is LTR': () => {
-            expect(mergeOptions(
+            expect(mergeConfig(
                 { foo: 1 },
                 { foo: 2 },
                 { foo: 3 },
@@ -39,7 +39,7 @@ export default {
                 foo: 3,
             });
 
-            expect(mergeOptions(
+            expect(mergeConfig(
                 { statusSuccess: 200 },
                 { statusSuccess: 201 },
                 { statusSuccess: 202 },
@@ -47,7 +47,7 @@ export default {
                 statusSuccess: [202],
             });
 
-            expect(mergeOptions(
+            expect(mergeConfig(
                 { statusValidationError: 400 },
                 { statusValidationError: 401 },
                 { statusValidationError: 402 },

--- a/test/router.js
+++ b/test/router.js
@@ -39,12 +39,12 @@ export default {
         },
     },
     'cant create router with route names which collide with router built-in methods': {
-        'options overwrite throws': () => {
+        'config overwrite throws': () => {
             expect(() => {
                 new Router({
-                    options: new Resource('kek'),
+                    config: new Resource('kek'),
                 });
-            }).to.throw(Error, /options collides with Router built-in method names/);
+            }).to.throw(Error, /config collides with Router built-in method names/);
         },
         'isBound overwrite throws': () => {
             expect(() => {
@@ -88,17 +88,17 @@ export default {
             expect(sdk.me).to.be.an.instanceof(Resource);
             expect(sdk.me.apiEndpoint).to.be.equal('user/me');
         },
-        'defaultOptions works': () => {
+        'defaultConfig works': () => {
             class SDK extends Router {
-                static defaultOptions = {
+                static defaultConfig = {
                     apiRoot: 'some/root',
                 };
             }
 
             const sdk = new SDK();
 
-            expect(sdk.options).to.be.an('object');
-            expect(sdk.options.apiRoot).to.be.equal('some/root');
+            expect(sdk.config).to.be.an('object');
+            expect(sdk.config.apiRoot).to.be.equal('some/root');
         },
     },
 };


### PR DESCRIPTION
- rename internal `.options` (per resource/router) to `.config`. This
   was needed to free up the name for `OPTIONS` request
- Docs: Added `method` argument to documented arguments for `fetch`

fixes #10