### PR TITLE
Deterministic config parse, tests, docs update

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,3 +7,4 @@ tmp
 coverage
 .nyc_output
 npm-debug.log
+.vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,25 +12,23 @@
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-### v1.1.0-alpha.1
+### v2.0.0-alpha.1
 
-
- * Removed deprecated `ValidationError.getFieldError`
- * Renamed internal `.options` (per resource/router) to `.config` (see #10)
-   * **Warning:** Breaking change if your code uses the internal API
+ * :exclamation: Removed deprecated `ValidationError.getFieldError`
+ * :exclamation: Renamed internal `.options` (per resource/router) to `.config` (see #10)
  * Added built-in for `OPTIONS` request: `Resource.options` (see #10)
- * `parseErrors` now gets parent config not parent instance as it's second
-     argument
+ * :exclamation: `parseErrors` now gets parent config not parent instance as it's second argument
  * Added new configuration parameter `mutateError` (see docs)
  * Added `defaultAcceptHeader` (see docs)
- * Removed `defaultHeaders` - use `headers` or `defaultAcceptHeader`
- * Setting `Accept` header to undefined/null does not cause the response to be parsed as text anymore. When migrating, just set `Accept` to `text/*`.
+ * :exclamation: Removed `defaultHeaders` - use `headers` or `defaultAcceptHeader`
+ * :exclamation: Setting `Accept` header to undefined/null does not cause the response to be parsed 
+    as text anymore. When migrating, just set `Accept` to `text/*`.
  * Removed separate `tg-resources-react-native` package. Users of older
-    versions of it can safely update to `tg-resources@1.1.0`
- * Update dev dependencies
+    versions of it can safely update to `tg-resources@2.0.0`
  * Deterministic config merge (+ tests for it)
  * Use `jsnext:main` and `module` fields in package.json
  * Use `react-native` field in package.json
+ * Update dev dependencies
  * Docs: Document extra arguments of `mutateResponse`
  * Docs: Add call signatures for `parseErrors`
  * Docs: Add call signatures for `prepareError`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,28 @@
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-### v1.1.0 [Not Released]
+### v1.1.0-alpha.1
 
- **Warning:** Breaking change (technically)
 
- * Renamed internal .options (per resource/router) to .config (see #10)
+ * Removed deprecated `ValidationError.getFieldError`
+ * Renamed internal `.options` (per resource/router) to `.config` (see #10)
+   * **Warning:** Breaking change if your code uses the internal API
  * Added built-in for `OPTIONS` request: `Resource.options` (see #10)
+ * `parseErrors` now gets parent config not parent instance as it's second
+     argument
+ * Added new configuration parameter `mutateError` (see docs)
+ * Added `defaultAcceptHeader` (see docs)
+ * Removed `defaultHeaders` - use `headers` or `defaultAcceptHeader`
+ * Setting `Accept` header to undefined/null does not cause the response to be parsed as text anymore. When migrating, just set `Accept` to `text/*`.
+ * Removed separate `tg-resources-react-native` package. Users of older
+    versions of it can safely update to `tg-resources@1.1.0`
+ * Update dev dependencies
+ * Deterministic config merge (+ tests for it)
+ * Use `jsnext:main` and `module` fields in package.json
+ * Use `react-native` field in package.json
+ * Docs: Document extra arguments of `mutateResponse`
+ * Docs: Add call signatures for `parseErrors`
+ * Docs: Add call signatures for `prepareError`
 
 ### v1.0.0
 

--- a/README.md
+++ b/README.md
@@ -16,13 +16,9 @@
 npm i tg-resources
 ```
 
-### react-native
+### Does it work on react native?
 
-For react-native please use `tg-resources-react-native` which does not depend on babel-runtime.
-
-#### Migrating to 1.0.0
-
-see the [Changelog](CHANGELOG.md#migrating-to-100)
+**YES**
 
 ## Basic Usage
 
@@ -68,14 +64,20 @@ endpoints. It's still possible to use Resources without a router(see [Resource a
 - ``headers`` *(Object|Function: Object)*: Optional Function or Object which can be used to add any additional headers to requests.
 - ``cookies`` *(Object|Function)*: Optional Function or Object which can be used to add any additional cookies to requests. Please note
                                    that in modern browsers this is disabled due to security concerns.
-- ``mutateResponse`` *(Function)*: Optional function with signature `response => response` which can be used to mutate response before
-                                   resolving it.
+- ``mutateResponse`` *(Function)*: Optional function with signature `(responseData, response, request) => responseData` which can be used to
+                                   mutate response data before resolving it. E.g. This can be used to provide access to raw response codes and
+                                   headers to your success handler.
+- ``mutateError`` *(Function)*: Optional function with signature `(error, response, request) => error` which can be used to
+                                   mutate errors before rejecting them. E.g. This can be used to provide access to raw response codes and
+                                   headers to your error handler.
 - ``statusSuccess`` *(Array[int])*: Array (or a single value) of status codes to treat as a success. Default: [200, 201, 204]
 - ``statusValidationError`` *(Array[int])*: Array (or a single value) of status codes to treat as ValidationError. Default: [400]
-- ``defaultHeaders`` *(Object)*: Object of headers which should be added to all requests: Default: `{ Accept: 'application/json' }`
-- ``parseErrors`` *(int)*: Function used to parse response errors into a ValidationError object. The default handler is built for Django/DRF
-                           errors.
-- ``prepareError`` *(int)*: Function used to normalize a single error. The default handler is built for Django/DRF errors.
+- ``defaultAcceptHeader`` *(String)*: Default accept header that is automatically added to requests (only if `headers.Accept=undefined`). Default:
+                                      `'application/json'`
+- ``parseErrors`` *(Function)*: Function with signature `(errorText, parentConfig) => [nonFieldErrors, errors]` which is used to parse response
+                                errors into a ValidationError object. The default handler is built for Django/DRF errors.
+- ``prepareError`` *(Function)*: Function with signature `(err, parentConfig) => mixed` which is used to normalize a single error. The default
+                                 handler is built for Django/DRF errors.
 
 ## Error handling
 
@@ -167,6 +169,10 @@ Do a get request to the resource endpoint with optional kwargs and query paramet
 2. `query={}` *(Object|string)*: Query parameters to use when doing the request.
 3. `method='get'` *(string)*: Lowercase name of the HTTP method that will be used for this request.
 
+### ``Resource.options``
+
+Alias for `Resource.fetch(kwargs, query, 'options')`
+
 #### Returns
 
 *(Promise)*:  Returns a `Promise` that resolves to the remote result or throws if errors occur.
@@ -255,10 +261,6 @@ Get field specific error
 ###### Returns
 
 *(any)*:  Returns a normalized error for ``fieldName`` or ``null``
-
-##### ``getFieldError``
-
-**Deprecated** alias of ``getError``
 
 ##### ``firstError``
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tg-resources",
-  "version": "1.0.0",
+  "version": "2.0.0-alpha.1",
   "description": "Abstractions on-top of `superagent` (or other Ajax libaries) for communication with REST.",
   "main": "./dist/index.js",
   "jsnext:main": "./es/index.js",

--- a/src/constants.js
+++ b/src/constants.js
@@ -4,6 +4,7 @@ import { ValidationError } from './errors';
 const DEFAULTS = {
     apiRoot: '',
     mutateResponse: null,
+    mutateError: null,
     headers: null,
     cookies: null,
 
@@ -13,9 +14,7 @@ const DEFAULTS = {
     statusSuccess: [200, 201, 204],
     statusValidationError: [400],
 
-    defaultHeaders: {
-        Accept: 'application/json',
-    },
+    defaultAcceptHeader: 'application/json',
 };
 
 export default DEFAULTS;

--- a/src/response.js
+++ b/src/response.js
@@ -1,17 +1,20 @@
 
 class ResponseWrapper {
-    constructor(response, error, disableDeserialize) {
-        this.response = response || {};
+    constructor(response, error) {
+        this._response = response;
         this._error = error;
-        this.disableDeserialize = disableDeserialize;
     }
 
-    get hasError() {
-        return !!this._error;
+    get response() {
+        return this._response || /* istanbul ignore next: safeguard */ {};
     }
 
     get error() {
         return this._error;
+    }
+
+    get hasError() {
+        return !!this.error;
     }
 
     /* istanbul ignore next */

--- a/src/router.js
+++ b/src/router.js
@@ -1,4 +1,5 @@
 import DEFAULTS from './constants';
+import { isFunction } from './typeChecks';
 import { bindResources, mergeConfig } from './util';
 
 
@@ -22,9 +23,19 @@ class Router {
         }
     }
 
+    getHeaders() {
+        const headers = {
+            ...(this.parent ? this.parent.getHeaders() : {}),
+            ...((isFunction(this.config.headers) ? this.config.headers() : this.config.headers) || {}),
+        };
+
+        return headers;
+    }
+
     getCookies() {
         return {
-            ...(this._parent ? this._parent.getCookies() : {}),
+            ...(this.parent ? this.parent.getCookies() : {}),
+            ...((isFunction(this.config.cookies) ? this.config.cookies() : this.config.cookies) || {}),
         };
     }
 
@@ -43,8 +54,7 @@ class Router {
     get config() {
         if (!this._config) {
             this._config = mergeConfig(
-                DEFAULTS,
-                this._parent ? this._parent.config : null,
+                this._parent ? this._parent.config : DEFAULTS,
                 this.defaultConfig || this.constructor.defaultConfig || null,
                 this._customConfig,
             );

--- a/src/single.js
+++ b/src/single.js
@@ -13,7 +13,7 @@ export default function makeSingle(baseClass) {
             return this.fetch(kwargs, query, 'options');
         }
 
-        post(kwargs, data, query, method = 'post') {
+        post(kwargs, data, query, /* istanbul ignore next: https://github.com/istanbuljs/babel-plugin-istanbul/issues/94 */ method = 'post') {
             const thePath = this.buildThePath(kwargs);
 
             return this.handleRequest(this.createRequest(method, thePath, query, data || {}));

--- a/test-server.js
+++ b/test-server.js
@@ -43,6 +43,12 @@ app.get('/headers', (req, res) => {
     }
 });
 
+app.options('/options', (req, res) => {
+    res.status(200).json({
+        message: 'options',
+    });
+});
+
 app.get('/cookies', (req, res) => {
     if (req.cookies.sessionid === 'secret') {
         res.status(200).json({

--- a/test/ValidationError.js
+++ b/test/ValidationError.js
@@ -77,19 +77,32 @@ export default {
             expect(instance.errors.email).to.be.a.instanceof(ValidationError);
             expect(instance.errors.email.errors.something).to.be.equal('be wrong yo');
         },
-        'getFieldError works': () => {
-            expect(instance.getFieldError).to.be.a('function');
+        'getFieldError has been removed': () => {
+            expect(instance.getFieldError).to.be.a('undefined');
+        },
+        'getError works': () => {
+            expect(instance.getError).to.be.a('function');
 
-            expect(instance.getFieldError('password')).to.be.equal('too short, missing numbers');
-            expect(instance.getFieldError('remember')).to.be.equal('false');
+            expect(instance.getError('password')).to.be.equal('too short, missing numbers');
+            expect(instance.getError('remember')).to.be.equal('false');
 
             // Nested ValidationError objects
-            expect(instance.getFieldError('email')).to.be.a.instanceof(ValidationError);
-            expect(instance.getFieldError('email').getFieldError).to.be.a('function');
-            expect(instance.getFieldError('email').getFieldError('something')).to.be.equal('be wrong yo');
+            expect(instance.getError('email')).to.be.a.instanceof(ValidationError);
+            expect(instance.getError('email').getError).to.be.a('function');
+            expect(instance.getError('email').getError('something')).to.be.equal('be wrong yo');
 
-            expect(instance.getFieldError('random-field')).to.be.a('null');
-            expect(instance.getFieldError('random-field', true)).to.be.equal('Something is generally broken');
+            // with allowNonField it should return nonFieldError (if no field specific errors exist)
+            expect(instance.getError('random-field')).to.be.a('null');
+            expect(instance.getError('random-field', true)).to.be.equal('Something is generally broken');
+            expect(instance.getError('password', true)).to.be.equal('too short, missing numbers');
+
+            // If no errors it should return null
+            const noErr = new ValidationError({
+                responseText: '{}',
+            });
+
+            expect(noErr.getError('foo')).to.be.a('null');
+            expect(noErr.getError('foo', true)).to.be.a('null');
         },
         'firstError works': () => {
             expect(instance.firstError).to.be.a('function');

--- a/test/router.js
+++ b/test/router.js
@@ -1,7 +1,48 @@
 import { expect } from 'chai';
 
 import Router, { Resource } from '../src';
+import DEFAULTS from '../src/constants';
 
+
+// Mocks
+const mockMutateResponse = x => x;
+const mockMutateError = x => x;
+
+const mockPrepareError = (...x) => DEFAULTS.prepareError(...x);
+const mockParseErrors = (...x) => DEFAULTS.parseErrors(...x);
+
+const expectConfig = (instance, expectedConfig) => {
+    const cfg = instance.config;
+
+    const deepEqualKeys = [
+        'statusValidationError',
+        'statusSuccess',
+        'cookies',
+        'headers',
+
+        'getCookies',
+        'getHeaders',
+    ];
+
+    // sort used so errors are deterministic
+    Object.keys(expectedConfig).sort().forEach((cfgKey) => {
+        let value = cfg[cfgKey];
+        const expected = expectedConfig[cfgKey];
+
+        // load values from instance methods
+        if (cfgKey === 'getCookies' || cfgKey === 'getHeaders') {
+            value = instance[cfgKey]();
+        }
+
+        if (deepEqualKeys.indexOf(cfgKey) !== -1) {
+            expect(value).to.deep.equal(expected,
+                `Config key '${cfgKey}' does not deeply match expected value`);
+        } else {
+            expect(value).to.equal(expected,
+                `Config key '${cfgKey}' does not match expected value (expected: '${expected}', is: '${value}')`);
+        }
+    });
+};
 
 export default {
     'routers work': {
@@ -36,6 +77,1023 @@ export default {
                     top: res,
                 });
             }).to.throw(Error, /Route 'top' is bound already/);
+        },
+        'isBound works': () => {
+            const res = new Resource('kek');
+
+            // should not be bound yet
+            expect(res.isBound).to.equal(false);
+
+            const api = new Router({
+                top: res,
+            });
+
+            // should be same refrence (not a copy)
+            expect(res).to.equal(api.top);
+
+            // should bound now
+            expect(res.isBound).to.equal(true);
+            expect(api.top.isBound).to.equal(true);
+
+            // parent for res should be api
+            expect(res.parent).to.equal(api);
+            expect(api.top.parent).to.equal(api);
+        },
+        'config flows down': () => {
+            const api = new Router({
+                aggressive: new Resource('rawr', {
+                    cookies: {
+                        from: 'resource',
+                    },
+                }),
+                submissive: new Resource('meow'),
+            }, {
+                apiRoot: 'http://foo.localhost/baz/',
+                cookies: {
+                    from: 'router',
+                    top: 'level',
+                },
+            });
+
+            // router cfg flows to submissive
+            expect(api.config.apiRoot).to.equal('http://foo.localhost/baz/');
+            expect(api.submissive.config.apiRoot).to.equal('http://foo.localhost/baz/');
+            expect(api.config.cookies).to.deep.equal({
+                from: 'router',
+                top: 'level',
+            });
+            expect(api.getCookies()).to.deep.equal({
+                from: 'router',
+                top: 'level',
+            });
+            expect(api.submissive.config.cookies).to.deep.equal({
+                from: 'router',
+                top: 'level',
+            });
+            expect(api.submissive.getCookies()).to.deep.equal({
+                from: 'router',
+                top: 'level',
+            });
+
+            // aggressive merges w/ parent
+            expect(api.aggressive.config.apiRoot).to.equal('http://foo.localhost/baz/');
+            // .config.cookies is not merged
+            expect(api.aggressive.config.cookies).to.deep.equal({
+                from: 'resource',
+            });
+            // getCookies is merged w/ parent
+            expect(api.aggressive.getCookies()).to.deep.equal({
+                from: 'resource',
+                top: 'level',
+            });
+        },
+    },
+    'router config merge -': {
+        'simple config keys flow down': () => {
+            const api = new Router({
+                aggressive: new Resource('rawr', {
+                    apiRoot: 'http://rawr.localhost/baz/',
+                    mutateResponse: mockMutateResponse,
+                    mutateError: mockMutateError,
+                    prepareError: mockPrepareError,
+                    parseErrors: mockParseErrors,
+                    statusValidationError: [5678],
+                    statusSuccess: [2337],
+                    defaultAcceptHeader: 'text/html',
+                }),
+                submissive: new Resource('meow'),
+            }, {
+                apiRoot: 'http://foo.localhost/baz/',
+                statusValidationError: [1234],
+                statusSuccess: [1337],
+            });
+
+            const routerLevelConfig = {
+                apiRoot: 'http://foo.localhost/baz/',
+                mutateResponse: null,
+                mutateError: null,
+                headers: null,
+                cookies: null,
+                prepareError: DEFAULTS.prepareError,
+                parseErrors: DEFAULTS.parseErrors,
+                statusValidationError: [1234],
+                statusSuccess: [1337],
+                defaultAcceptHeader: DEFAULTS.defaultAcceptHeader,
+            };
+
+            // correct on router level
+            expectConfig(api, routerLevelConfig);
+
+            // submissive uses router level stuff
+            expectConfig(api.submissive, routerLevelConfig);
+
+            // aggressive overwrites stuff
+            expectConfig(api.aggressive, {
+                ...routerLevelConfig,
+                apiRoot: 'http://rawr.localhost/baz/',
+                mutateResponse: mockMutateResponse,
+                mutateError: mockMutateError,
+                prepareError: mockPrepareError,
+                parseErrors: mockParseErrors,
+                statusValidationError: [5678],
+                statusSuccess: [2337],
+                defaultAcceptHeader: 'text/html',
+            });
+        },
+        'simple config keys flow down [nested routers]': () => {
+            const api = new Router({
+                aggressive: new Router({
+                    first: new Resource('rawr'),
+                }, {
+                    apiRoot: 'http://rawr.localhost/baz/',
+                    mutateResponse: mockMutateResponse,
+                    mutateError: mockMutateError,
+                    prepareError: mockPrepareError,
+                    parseErrors: mockParseErrors,
+                    statusValidationError: [5678],
+                    statusSuccess: [2337],
+                    defaultAcceptHeader: 'text/html',
+                }),
+                submissive: new Router({
+                    first: new Resource('meow'),
+                }),
+            }, {
+                apiRoot: 'http://foo.localhost/baz/',
+                statusValidationError: [1234],
+                statusSuccess: [1337],
+            });
+
+            const routerLevelConfig = {
+                apiRoot: 'http://foo.localhost/baz/',
+                mutateResponse: null,
+                mutateError: null,
+                headers: null,
+                cookies: null,
+                prepareError: DEFAULTS.prepareError,
+                parseErrors: DEFAULTS.parseErrors,
+                statusValidationError: [1234],
+                statusSuccess: [1337],
+                defaultAcceptHeader: DEFAULTS.defaultAcceptHeader,
+            };
+
+            // correct on router level
+            expectConfig(api, routerLevelConfig);
+
+            // submissive uses router level stuff
+            expectConfig(api.submissive, routerLevelConfig);
+            expectConfig(api.submissive.first, routerLevelConfig);
+
+            // aggressive overwrites stuff
+            const aggressiveLevelConfig = {
+                ...routerLevelConfig,
+                apiRoot: 'http://rawr.localhost/baz/',
+                mutateResponse: mockMutateResponse,
+                mutateError: mockMutateError,
+                prepareError: mockPrepareError,
+                parseErrors: mockParseErrors,
+                statusValidationError: [5678],
+                statusSuccess: [2337],
+                defaultAcceptHeader: 'text/html',
+            };
+            expectConfig(api.aggressive, aggressiveLevelConfig);
+            expectConfig(api.aggressive.first, aggressiveLevelConfig);
+        },
+        'cookies flow down': () => {
+            const api = new Router({
+                aggressive: new Resource('rawr', {
+                    cookies: {
+                        from: 'resource',
+                        will_be: null,
+                    },
+                }),
+                submissive: new Resource('meow'),
+            }, {
+                cookies: {
+                    from: 'router',
+                    top: 'level',
+                    will_be: 'deleted',
+                },
+            });
+
+            const routerLevelConfig = {
+                cookies: {
+                    from: 'router',
+                    top: 'level',
+                    will_be: 'deleted',
+                },
+            };
+
+            // correct on router level
+            expectConfig(api, routerLevelConfig);
+
+            // submissive uses router level stuff
+            expectConfig(api.submissive, routerLevelConfig);
+
+            // aggressive overwrites stuff
+            expectConfig(api.aggressive, {
+                cookies: {
+                    from: 'resource',
+                    will_be: null,
+                },
+                getCookies: {
+                    from: 'resource',
+                    top: 'level',
+                    will_be: null,
+                },
+            });
+        },
+        'cookies flow down [nested routers]': () => {
+            const api = new Router({
+                aggressive: new Router({
+                    first: new Resource('rawr'),
+                }, {
+                    cookies: {
+                        from: 'resource',
+                        will_be: null,
+                    },
+                }),
+                submissive: new Router({
+                    first: new Resource('meow'),
+                }),
+            }, {
+                cookies: {
+                    from: 'router',
+                    top: 'level',
+                    will_be: 'deleted',
+                },
+            });
+
+            const routerLevelConfig = {
+                cookies: {
+                    from: 'router',
+                    top: 'level',
+                    will_be: 'deleted',
+                },
+                getCookies: {
+                    from: 'router',
+                    top: 'level',
+                    will_be: 'deleted',
+                },
+            };
+
+            // correct on router level
+            expectConfig(api, routerLevelConfig);
+
+            // submissive uses router level stuff
+            expectConfig(api.submissive, routerLevelConfig);
+            expectConfig(api.submissive.first, routerLevelConfig);
+
+            // aggressive overwrites stuff
+            const aggressiveLevelConfig = {
+                cookies: {
+                    from: 'resource',
+                    will_be: null,
+                },
+                getCookies: {
+                    from: 'resource',
+                    top: 'level',
+                    will_be: null,
+                },
+            };
+            expectConfig(api.aggressive, aggressiveLevelConfig);
+            expectConfig(api.aggressive.first, aggressiveLevelConfig);
+        },
+        'func cookies flow down': () => {
+            const genericCookies = () => ({
+                from: 'router',
+                top: 'level',
+                will_be: 'deleted',
+            });
+            const aggressiveCookies = () => ({
+                from: 'resource',
+                will_be: null,
+            });
+
+            const api = new Router({
+                aggressive: new Resource('rawr', {
+                    cookies: aggressiveCookies,
+                }),
+                submissive: new Resource('meow'),
+            }, {
+                cookies: genericCookies,
+            });
+
+            const routerLevelConfig = {
+                cookies: genericCookies,
+                getCookies: genericCookies(),
+            };
+
+            // correct on router level
+            expectConfig(api, routerLevelConfig);
+
+            // submissive uses router level stuff
+            expectConfig(api.submissive, routerLevelConfig);
+
+            // aggressive overwrites stuff
+            expectConfig(api.aggressive, {
+                cookies: aggressiveCookies,
+                getCookies: {
+                    ...genericCookies(),
+                    ...aggressiveCookies(),
+                },
+            });
+        },
+        'func cookies flow down [nested routers]': () => {
+            const genericCookies = () => ({
+                from: 'router',
+                top: 'level',
+                will_be: 'deleted',
+            });
+            const aggressiveCookies = () => ({
+                from: 'resource',
+                will_be: null,
+            });
+
+            const api = new Router({
+                aggressive: new Router({
+                    first: new Resource('rawr'),
+                }, {
+                    cookies: aggressiveCookies,
+                }),
+                submissive: new Router({
+                    first: new Resource('meow'),
+                }),
+            }, {
+                cookies: genericCookies,
+            });
+
+            const routerLevelConfig = {
+                cookies: genericCookies,
+                getCookies: genericCookies(),
+            };
+
+            // correct on router level
+            expectConfig(api, routerLevelConfig);
+
+            // submissive uses router level stuff
+            expectConfig(api.submissive, routerLevelConfig);
+            expectConfig(api.submissive.first, routerLevelConfig);
+
+            // aggressive overwrites stuff
+            const aggressiveLevelConfig = {
+                cookies: aggressiveCookies,
+                getCookies: {
+                    ...genericCookies(),
+                    ...aggressiveCookies(),
+                },
+            };
+            expectConfig(api.aggressive, aggressiveLevelConfig);
+            expectConfig(api.aggressive.first, aggressiveLevelConfig);
+        },
+        'mixed (obj -> fn) cookies flow down': () => {
+            const aggressiveCookies = () => ({
+                from: 'resource',
+                will_be: null,
+            });
+
+            const api = new Router({
+                aggressive: new Resource('rawr', {
+                    cookies: aggressiveCookies,
+                }),
+                submissive: new Resource('meow'),
+            }, {
+                cookies: {
+                    from: 'router',
+                    top: 'level',
+                    will_be: 'deleted',
+                },
+            });
+
+            const routerLevelConfig = {
+                cookies: {
+                    from: 'router',
+                    top: 'level',
+                    will_be: 'deleted',
+                },
+                getCookies: {
+                    from: 'router',
+                    top: 'level',
+                    will_be: 'deleted',
+                },
+            };
+
+            // correct on router level
+            expectConfig(api, routerLevelConfig);
+
+            // submissive uses router level stuff
+            expectConfig(api.submissive, routerLevelConfig);
+
+            // aggressive overwrites stuff
+            expectConfig(api.aggressive, {
+                cookies: aggressiveCookies,
+                getCookies: {
+                    ...routerLevelConfig.cookies,
+                    ...aggressiveCookies(),
+                },
+            });
+        },
+        'mixed (obj -> fn) cookies flow down [nested routers]': () => {
+            const aggressiveCookies = () => ({
+                from: 'resource',
+                will_be: null,
+            });
+
+            const api = new Router({
+                aggressive: new Router({
+                    first: new Resource('rawr'),
+                }, {
+                    cookies: aggressiveCookies,
+                }),
+                submissive: new Router({
+                    first: new Resource('meow'),
+                }),
+            }, {
+                cookies: {
+                    from: 'router',
+                    top: 'level',
+                    will_be: 'deleted',
+                },
+            });
+
+            const routerLevelConfig = {
+                cookies: {
+                    from: 'router',
+                    top: 'level',
+                    will_be: 'deleted',
+                },
+                getCookies: {
+                    from: 'router',
+                    top: 'level',
+                    will_be: 'deleted',
+                },
+            };
+
+            // correct on router level
+            expectConfig(api, routerLevelConfig);
+
+            // submissive uses router level stuff
+            expectConfig(api.submissive, routerLevelConfig);
+            expectConfig(api.submissive.first, routerLevelConfig);
+
+            // aggressive overwrites stuff
+            const aggressiveLevelConfig = {
+                cookies: aggressiveCookies,
+                getCookies: {
+                    ...routerLevelConfig.cookies,
+                    ...aggressiveCookies(),
+                },
+            };
+            expectConfig(api.aggressive, aggressiveLevelConfig);
+            expectConfig(api.aggressive.first, aggressiveLevelConfig);
+        },
+        'mixed (fn -> obj) cookies flow down': () => {
+            const genericCookies = () => ({
+                from: 'router',
+                top: 'level',
+                will_be: 'deleted',
+            });
+
+            const api = new Router({
+                aggressive: new Resource('rawr', {
+                    cookies: {
+                        from: 'resource',
+                        will_be: null,
+                    },
+                }),
+                submissive: new Resource('meow'),
+            }, {
+                cookies: genericCookies,
+            });
+
+            const routerLevelConfig = {
+                cookies: genericCookies,
+                getCookies: genericCookies(),
+            };
+
+            // correct on router level
+            expectConfig(api, routerLevelConfig);
+
+            // submissive uses router level stuff
+            expectConfig(api.submissive, routerLevelConfig);
+
+            // aggressive overwrites stuff
+            expectConfig(api.aggressive, {
+                cookies: {
+                    from: 'resource',
+                    will_be: null,
+                },
+                getCookies: {
+                    ...genericCookies(),
+                    from: 'resource',
+                    will_be: null,
+                },
+            });
+        },
+        'mixed (fn -> obj) cookies flow down [nested routers]': () => {
+            const genericCookies = () => ({
+                from: 'router',
+                top: 'level',
+                will_be: 'deleted',
+            });
+
+            const api = new Router({
+                aggressive: new Router({
+                    first: new Resource('rawr'),
+                }, {
+                    cookies: {
+                        from: 'resource',
+                        will_be: null,
+                    },
+                }),
+                submissive: new Router({
+                    first: new Resource('meow'),
+                }),
+            }, {
+                cookies: genericCookies,
+            });
+
+            const routerLevelConfig = {
+                cookies: genericCookies,
+                getCookies: genericCookies(),
+            };
+
+            // correct on router level
+            expectConfig(api, routerLevelConfig);
+
+            // submissive uses router level stuff
+            expectConfig(api.submissive, routerLevelConfig);
+            expectConfig(api.submissive.first, routerLevelConfig);
+
+            // aggressive overwrites stuff
+            const aggressiveLevelConfig = {
+                cookies: {
+                    from: 'resource',
+                    will_be: null,
+                },
+                getCookies: {
+                    ...genericCookies(),
+                    from: 'resource',
+                    will_be: null,
+                },
+            };
+            expectConfig(api.aggressive, aggressiveLevelConfig);
+            expectConfig(api.aggressive.first, aggressiveLevelConfig);
+        },
+
+        'headers flow down': () => {
+            const api = new Router({
+                aggressive: new Resource('rawr', {
+                    headers: {
+                        from: 'resource',
+                        will_be: null,
+                    },
+                }),
+                submissive: new Resource('meow'),
+            }, {
+                headers: {
+                    from: 'router',
+                    top: 'level',
+                    will_be: 'deleted',
+                },
+            });
+
+            const routerLevelConfig = {
+                headers: {
+                    from: 'router',
+                    top: 'level',
+                    will_be: 'deleted',
+                },
+            };
+
+            // correct on router level
+            expectConfig(api, routerLevelConfig);
+
+            // submissive uses router level stuff
+            expectConfig(api.submissive, routerLevelConfig);
+
+            // aggressive overwrites stuff
+            expectConfig(api.aggressive, {
+                headers: {
+                    from: 'resource',
+                    will_be: null,
+                },
+                getHeaders: {
+                    from: 'resource',
+                    top: 'level',
+                    will_be: null,
+                    Accept: 'application/json',
+                },
+            });
+        },
+        'headers flow down [nested routers]': () => {
+            const api = new Router({
+                aggressive: new Router({
+                    first: new Resource('rawr'),
+                }, {
+                    headers: {
+                        from: 'resource',
+                        will_be: null,
+                    },
+                }),
+                submissive: new Router({
+                    first: new Resource('meow'),
+                }),
+            }, {
+                headers: {
+                    from: 'router',
+                    top: 'level',
+                    will_be: 'deleted',
+                },
+            });
+
+            const routerLevelConfig = {
+                headers: {
+                    from: 'router',
+                    top: 'level',
+                    will_be: 'deleted',
+                },
+                getHeaders: {
+                    from: 'router',
+                    top: 'level',
+                    will_be: 'deleted',
+                },
+            };
+
+            // correct on router level
+            expectConfig(api, routerLevelConfig);
+
+            // submissive uses router level stuff
+            expectConfig(api.submissive, routerLevelConfig);
+            expectConfig(api.submissive.first, {
+                ...routerLevelConfig,
+                getHeaders: {
+                    ...routerLevelConfig.getHeaders,
+                    Accept: 'application/json',
+                },
+            });
+
+            // aggressive overwrites stuff
+            const aggressiveLevelConfig = {
+                headers: {
+                    from: 'resource',
+                    will_be: null,
+                },
+                getHeaders: {
+                    from: 'resource',
+                    top: 'level',
+                    will_be: null,
+                },
+            };
+            expectConfig(api.aggressive, aggressiveLevelConfig);
+            expectConfig(api.aggressive.first, {
+                ...aggressiveLevelConfig,
+                getHeaders: {
+                    ...aggressiveLevelConfig.getHeaders,
+                    Accept: 'application/json',
+                },
+            });
+        },
+        'func headers flow down': () => {
+            const genericHeaders = () => ({
+                from: 'router',
+                top: 'level',
+                will_be: 'deleted',
+            });
+            const aggressiveHeaders = () => ({
+                from: 'resource',
+                will_be: null,
+            });
+
+            const api = new Router({
+                aggressive: new Resource('rawr', {
+                    headers: aggressiveHeaders,
+                }),
+                submissive: new Resource('meow'),
+            }, {
+                headers: genericHeaders,
+            });
+
+            const routerLevelConfig = {
+                headers: genericHeaders,
+                getHeaders: genericHeaders(),
+            };
+
+            // correct on router level
+            expectConfig(api, routerLevelConfig);
+
+            // submissive uses router level stuff
+            expectConfig(api.submissive, {
+                ...routerLevelConfig,
+                getHeaders: {
+                    ...routerLevelConfig.getHeaders,
+                    Accept: 'application/json',
+                },
+            });
+
+            // aggressive overwrites stuff
+            expectConfig(api.aggressive, {
+                headers: aggressiveHeaders,
+                getHeaders: {
+                    Accept: 'application/json',
+                    ...genericHeaders(),
+                    ...aggressiveHeaders(),
+                },
+            });
+        },
+        'func headers flow down [nested routers]': () => {
+            const genericHeaders = () => ({
+                from: 'router',
+                top: 'level',
+                will_be: 'deleted',
+            });
+            const aggressiveHeaders = () => ({
+                from: 'resource',
+                will_be: null,
+            });
+
+            const api = new Router({
+                aggressive: new Router({
+                    first: new Resource('rawr'),
+                }, {
+                    headers: aggressiveHeaders,
+                }),
+                submissive: new Router({
+                    first: new Resource('meow'),
+                }),
+            }, {
+                headers: genericHeaders,
+            });
+
+            const routerLevelConfig = {
+                headers: genericHeaders,
+                getHeaders: {
+                    ...genericHeaders(),
+                },
+            };
+
+            // correct on router level
+            expectConfig(api, routerLevelConfig);
+
+            // submissive uses router level stuff
+            expectConfig(api.submissive, routerLevelConfig);
+            expectConfig(api.submissive.first, {
+                ...routerLevelConfig,
+                getHeaders: {
+                    Accept: 'application/json',
+                    ...routerLevelConfig.getHeaders,
+                },
+            });
+
+            // aggressive overwrites stuff
+            const aggressiveLevelConfig = {
+                headers: aggressiveHeaders,
+                getHeaders: {
+                    ...genericHeaders(),
+                    ...aggressiveHeaders(),
+                },
+            };
+            expectConfig(api.aggressive, aggressiveLevelConfig);
+            expectConfig(api.aggressive.first, {
+                ...aggressiveLevelConfig,
+                getHeaders: {
+                    ...aggressiveLevelConfig.getHeaders,
+                    Accept: 'application/json',
+                },
+            });
+        },
+        'mixed (obj -> fn) headers flow down': () => {
+            const aggressiveHeaders = () => ({
+                from: 'resource',
+                will_be: null,
+            });
+
+            const api = new Router({
+                aggressive: new Resource('rawr', {
+                    headers: aggressiveHeaders,
+                }),
+                submissive: new Resource('meow'),
+            }, {
+                headers: {
+                    from: 'router',
+                    top: 'level',
+                    will_be: 'deleted',
+                },
+            });
+
+            const routerLevelConfig = {
+                headers: {
+                    from: 'router',
+                    top: 'level',
+                    will_be: 'deleted',
+                },
+                getHeaders: {
+                    from: 'router',
+                    top: 'level',
+                    will_be: 'deleted',
+                },
+            };
+
+            // correct on router level
+            expectConfig(api, routerLevelConfig);
+
+            // submissive uses router level stuff
+            expectConfig(api.submissive, {
+                ...routerLevelConfig,
+                getHeaders: {
+                    ...routerLevelConfig.getHeaders,
+                    Accept: 'application/json',
+                },
+            });
+
+            // aggressive overwrites stuff
+            expectConfig(api.aggressive, {
+                headers: aggressiveHeaders,
+                getHeaders: {
+                    ...routerLevelConfig.headers,
+                    ...aggressiveHeaders(),
+                    Accept: 'application/json',
+                },
+            });
+        },
+        'mixed (obj -> fn) headers flow down [nested routers]': () => {
+            const aggressiveHeaders = () => ({
+                from: 'resource',
+                will_be: null,
+            });
+
+            const api = new Router({
+                aggressive: new Router({
+                    first: new Resource('rawr'),
+                }, {
+                    headers: aggressiveHeaders,
+                }),
+                submissive: new Router({
+                    first: new Resource('meow'),
+                }),
+            }, {
+                headers: {
+                    from: 'router',
+                    top: 'level',
+                    will_be: 'deleted',
+                },
+            });
+
+            const routerLevelConfig = {
+                headers: {
+                    from: 'router',
+                    top: 'level',
+                    will_be: 'deleted',
+                },
+                getHeaders: {
+                    from: 'router',
+                    top: 'level',
+                    will_be: 'deleted',
+                },
+            };
+
+            // correct on router level
+            expectConfig(api, routerLevelConfig);
+
+            // submissive uses router level stuff
+            expectConfig(api.submissive, routerLevelConfig);
+            expectConfig(api.submissive.first, {
+                ...routerLevelConfig,
+                getHeaders: {
+                    ...routerLevelConfig.getHeaders,
+                    Accept: 'application/json',
+                },
+            });
+
+            // aggressive overwrites stuff
+            const aggressiveLevelConfig = {
+                headers: aggressiveHeaders,
+                getHeaders: {
+                    ...routerLevelConfig.headers,
+                    ...aggressiveHeaders(),
+                },
+            };
+            expectConfig(api.aggressive, aggressiveLevelConfig);
+            expectConfig(api.aggressive.first, {
+                ...aggressiveLevelConfig,
+                getHeaders: {
+                    ...aggressiveLevelConfig.getHeaders,
+                    Accept: 'application/json',
+                },
+            });
+        },
+        'mixed (fn -> obj) headers flow down': () => {
+            const genericHeaders = () => ({
+                from: 'router',
+                top: 'level',
+                will_be: 'deleted',
+            });
+
+            const api = new Router({
+                aggressive: new Resource('rawr', {
+                    headers: {
+                        from: 'resource',
+                        will_be: null,
+                    },
+                }),
+                submissive: new Resource('meow'),
+            }, {
+                headers: genericHeaders,
+            });
+
+            const routerLevelConfig = {
+                headers: genericHeaders,
+                getHeaders: {
+                    ...genericHeaders(),
+                },
+            };
+
+            // correct on router level
+            expectConfig(api, routerLevelConfig);
+
+            // submissive uses router level stuff
+            expectConfig(api.submissive, {
+                ...routerLevelConfig,
+                getHeaders: {
+                    ...routerLevelConfig.getHeaders,
+                    Accept: 'application/json',
+                },
+            });
+
+            // aggressive overwrites stuff
+            expectConfig(api.aggressive, {
+                headers: {
+                    from: 'resource',
+                    will_be: null,
+                },
+                getHeaders: {
+                    ...genericHeaders(),
+                    from: 'resource',
+                    will_be: null,
+                    Accept: 'application/json',
+                },
+            });
+        },
+        'mixed (fn -> obj) headers flow down [nested routers]': () => {
+            const genericHeaders = () => ({
+                from: 'router',
+                top: 'level',
+                will_be: 'deleted',
+            });
+
+            const api = new Router({
+                aggressive: new Router({
+                    first: new Resource('rawr'),
+                }, {
+                    headers: {
+                        from: 'resource',
+                        will_be: null,
+                    },
+                }),
+                submissive: new Router({
+                    first: new Resource('meow'),
+                }),
+            }, {
+                headers: genericHeaders,
+            });
+
+            const routerLevelConfig = {
+                headers: genericHeaders,
+                getHeaders: genericHeaders(),
+            };
+
+            // correct on router level
+            expectConfig(api, routerLevelConfig);
+
+            // submissive uses router level stuff
+            expectConfig(api.submissive, routerLevelConfig);
+            expectConfig(api.submissive.first, {
+                ...routerLevelConfig,
+                getHeaders: {
+                    ...routerLevelConfig.getHeaders,
+                    Accept: 'application/json',
+                },
+            });
+
+            // aggressive overwrites stuff
+            const aggressiveLevelConfig = {
+                headers: {
+                    from: 'resource',
+                    will_be: null,
+                },
+                getHeaders: {
+                    ...genericHeaders(),
+                    from: 'resource',
+                    will_be: null,
+                },
+            };
+            expectConfig(api.aggressive, aggressiveLevelConfig);
+            expectConfig(api.aggressive.first, {
+                ...aggressiveLevelConfig,
+                getHeaders: {
+                    ...aggressiveLevelConfig.getHeaders,
+                    Accept: 'application/json',
+                },
+            });
         },
     },
     'cant create router with route names which collide with router built-in methods': {

--- a/yarn.lock
+++ b/yarn.lock
@@ -546,6 +546,12 @@ babel-plugin-transform-regenerator@^6.24.1:
   dependencies:
     regenerator-transform "0.9.11"
 
+babel-plugin-transform-runtime@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz#88490d446502ea9b8e7efb0fe09ec4d99479b1ee"
+  dependencies:
+    babel-runtime "^6.22.0"
+
 babel-plugin-transform-strict-mode@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz#d5faf7aa578a65bbe591cf5edae04a0c67020758"
@@ -970,11 +976,26 @@ coveralls@*:
     minimist "1.2.0"
     request "2.79.0"
 
+cross-env@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.0.1.tgz#ff4e72ea43b47da2486b43a7f2043b2609e44913"
+  dependencies:
+    cross-spawn "^5.1.0"
+    is-windows "^1.0.0"
+
 cross-spawn@^4, cross-spawn@^4.0.0:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-4.0.2.tgz#7b9247621c23adfdd3856004a823cbe397424d41"
   dependencies:
     lru-cache "^4.0.1"
+    which "^1.2.9"
+
+cross-spawn@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
+  dependencies:
+    lru-cache "^4.0.1"
+    shebang-command "^1.2.0"
     which "^1.2.9"
 
 cryptiles@2.x.x:
@@ -2038,6 +2059,10 @@ is-typedarray@~1.0.0:
 is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
+
+is-windows@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.1.tgz#310db70f742d259a16a369202b51af84233310d9"
 
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
@@ -3202,6 +3227,16 @@ set-immediate-shim@^1.0.1:
 setprototypeof@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.0.3.tgz#66567e37043eeb4f04d91bd658c0cbefb55b8e04"
+
+shebang-command@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
+  dependencies:
+    shebang-regex "^1.0.0"
+
+shebang-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
 
 shelljs@^0.7.5:
   version "0.7.8"


### PR DESCRIPTION
 * Removed deprecated `ValidationError.getFieldError`
 * `parseErrors` now gets parent config not parent instance as it's second
     argument
 * Added new configuration parameter `mutateError` (see docs)
 * Added `defaultAcceptHeader` (see docs)
 * Removed `defaultHeaders` - use `headers` or `defaultAcceptHeader`
 * Setting `Accept` header to undefined/null does not cause the response to be parsed as text anymore. When migrating, just set `Accept` to `text/*`.
 * Add test for `.options` method
 * Docs: Document extra arguments of `mutateResponse`
 * Docs: Add call signatures for `parseErrors`
 * Docs: Add call signatures for `prepareError`
 * Docs: Document `options` method

fixes #7
fixes #10