### PR TITLE
Error parser improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,12 +64,12 @@ endpoints. It's still possible to use Resources without a router(see [Resource a
 - ``headers`` *(Object|Function: Object)*: Optional Function or Object which can be used to add any additional headers to requests.
 - ``cookies`` *(Object|Function)*: Optional Function or Object which can be used to add any additional cookies to requests. Please note
                                    that in modern browsers this is disabled due to security concerns.
-- ``mutateResponse`` *(Function)*: Optional function with signature `(responseData, response, request) => responseData` which can be used to
-                                   mutate response data before resolving it. E.g. This can be used to provide access to raw response codes and
-                                   headers to your success handler.
-- ``mutateError`` *(Function)*: Optional function with signature `(error, response, request) => error` which can be used to
-                                   mutate errors before rejecting them. E.g. This can be used to provide access to raw response codes and
-                                   headers to your error handler.
+- ``mutateResponse`` *(Function)*: Optional function with signature `(responseData, rawResponse: ResponseWrapper, resource: Resource) => responseData` 
+                                   which can be used to mutate response data before resolving it. E.g. This can be used to provide access to raw 
+                                   response codes and headers to your success handler.
+- ``mutateError`` *(Function)*: Optional function with signature `(error: BaseResourceError, rawResponse: ResponseWrapper, resource: Resource) => error`
+                                which can be used to mutate errors before rejecting them. E.g. This can be used to provide access to raw response codes 
+                                and headers to your error handler.
 - ``statusSuccess`` *(Array[int])*: Array (or a single value) of status codes to treat as a success. Default: [200, 201, 204]
 - ``statusValidationError`` *(Array[int])*: Array (or a single value) of status codes to treat as ValidationError. Default: [400]
 - ``defaultAcceptHeader`` *(String)*: Default accept header that is automatically added to requests (only if `headers.Accept=undefined`). Default:
@@ -78,6 +78,9 @@ endpoints. It's still possible to use Resources without a router(see [Resource a
                                 errors into a ValidationError object. The default handler is built for Django/DRF errors.
 - ``prepareError`` *(Function)*: Function with signature `(err, parentConfig) => mixed` which is used to normalize a single error. The default
                                  handler is built for Django/DRF errors.
+- ``mutateRawResponse`` *(Function)*: **Advanced usage:** Optional function with signature `rawResponse: ResponseWrapper => rawResponse` which can be
+                                      used to mutate the response before it is resolved to `responseData` or a `BaseResourceError` subclass. Use the 
+                                      source of `ResponseWrapper`, `SuperagentResponse` and `GenericResource::ensureStatusAndJson` for guidance.
 
 ## Error handling
 

--- a/package.json
+++ b/package.json
@@ -14,11 +14,10 @@
   "scripts": {
     "clean": "$(npm bin)/rimraf dist",
     "lint": "$(npm bin)/eslint src test",
-    "pretest": "npm run lint",
     "test": "cross-env BABEL_ENV=test $(npm bin)/nyc mocha -u exports test/*.js",
     "coverage": "$(npm bin)/nyc report && $(npm bin)/nyc report --reporter=html",
     "coveralls": "$(npm bin)/nyc report --reporter=text-lcov | $(npm bin)/coveralls",
-    "prebuild": "npm run clean -s",
+    "prebuild": "npm run clean -s && npm run lint",
     "build": "npm run build:umd && npm run build:es",
     "build:umd": "cross-env BABEL_ENV=commonjs $(npm bin)/babel src -d dist",
     "build:es": "cross-env BABEL_ENV=es $(npm bin)/babel src -d es",
@@ -68,6 +67,7 @@
     "mocha": "^3.4.2",
     "nyc": "^11.0.3",
     "rimraf": "*",
+    "sinon": "^2.3.8",
     "superagent": "^3.5.2",
     "uuid": "*",
     "watch": "*"

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,15 +1,16 @@
-import { ValidationError } from './errors';
+import { defaultParseErrors, defaultPrepareError } from './validationError';
 
 
 const DEFAULTS = {
     apiRoot: '',
     mutateResponse: null,
     mutateError: null,
+    mutateRawResponse: null,
     headers: null,
     cookies: null,
 
-    prepareError: ValidationError.defaultPrepareError,
-    parseErrors: ValidationError.defaultParseErrors,
+    parseErrors: defaultParseErrors,
+    prepareError: defaultPrepareError,
 
     statusSuccess: [200, 201, 204],
     statusValidationError: [400],

--- a/src/errors.js
+++ b/src/errors.js
@@ -1,5 +1,6 @@
-import { isArray, isObject, isString } from './typeChecks';
+import { hasValue } from './typeChecks';
 import { truncate } from './util';
+import { parseErrors, prepareError } from './validationError';
 
 
 export class BaseResourceError {
@@ -49,31 +50,22 @@ export class InvalidResponseCode extends BaseResourceError {
     }
 }
 
+export class RequestValidationError extends InvalidResponseCode {
+    constructor(statusCode, responseText, config = null) {
+        super(statusCode, responseText, 'RequestValidationError');
 
-export class ValidationError extends InvalidResponseCode {
-    constructor(err, config = null, isPrepared = false) {
-        if (isPrepared) {
-            err = {
-                responseText: err,
-            };
-        }
-
-        err = {
-            statusCode: 0,
-            responseText: '',
-            ...err,
+        // Set custom config
+        this._customConfig = {
+            parseErrors,
+            prepareError,
+            ...config || {},
         };
 
-        super(err.statusCode, err.responseText, 'ValidationError');
-
-        this._customConfig = config || {};
-
-        const handler = this._customConfig.parseErrors || ValidationError.defaultParseErrors;
-        const res = handler(err.responseText, this._customConfig);
-        this.nonFieldErrors = res[0] || null;
-        this.errors = res[1] || /* istanbul ignore next: can only happen w/ custom parseErrors */ {};
+        // parse response body as a ValidationError
+        this._errors = this._customConfig.parseErrors(responseText, this._customConfig);
     }
 
+    // public api
     get isValidationError() { // eslint-disable-line class-methods-use-this
         return true;
     }
@@ -82,71 +74,11 @@ export class ValidationError extends InvalidResponseCode {
         return false;
     }
 
-    getError(fieldName, allowNonFields) {
-        if (this.errors[fieldName] || (allowNonFields && this.nonFieldErrors)) {
-            return this.errors[fieldName] || this.nonFieldErrors;
-        }
-
-        return null;
+    get errors() {
+        return this._errors;
     }
 
-    firstError(allowNonField) {
-        if (allowNonField && this.nonFieldErrors) {
-            return this.nonFieldErrors;
-        }
-
-        const errs = Object.keys(this.errors);
-
-        if (errs.length > 0) {
-            return this.errors[errs[0]];
-        }
-
-        return null;
-    }
-
-    static defaultParseErrors(errorText, parentConfig) {
-        if (isString(errorText)) {
-            if (errorText) {
-                errorText = JSON.parse(errorText);
-            } else {
-                errorText = {};
-            }
-        }
-
-        let resNonField = null;
-        const resErrors = {};
-
-        const prepareError = parentConfig.prepareError || ValidationError.defaultPrepareError;
-
-        const errors = typeof errorText.errors === 'undefined' ? errorText : errorText.errors;
-        Object.keys(errors).forEach((key) => {
-            if (key === 'non_field_errors') {
-                resNonField = prepareError(errors[key], parentConfig);
-            }
-            else {
-                resErrors[key] = prepareError(errors[key], parentConfig);
-            }
-        });
-
-        return [resNonField, resErrors];
-    }
-
-    static defaultPrepareError(err, parentConfig) {
-        if (isString(err)) {
-            return err;
-        }
-
-        else if (isArray(err)) {
-            return err.join(', ');
-        }
-
-        else if (isObject(err)) {
-            // Note: We clone the object just in case
-            return new ValidationError(Object.assign({}, err), parentConfig, true);
-        }
-
-        else {
-            return `${err}`;
-        }
+    hasError() {
+        return hasValue(this._errors) && this._errors.hasError();
     }
 }

--- a/src/generic.js
+++ b/src/generic.js
@@ -1,5 +1,5 @@
 // We use superagent as a default worker
-import SuperAgentResource from './superagent';
+import SuperAgentResource, { SuperagentResponse } from './superagent';
 
 
 // import SingleObjectResource factory
@@ -9,3 +9,4 @@ import makeSingle from './single';
 // Export everything
 export const GenericResource = SuperAgentResource;
 export const Resource = makeSingle(SuperAgentResource);
+export const Response = SuperagentResponse;

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,28 @@
 // Export everything
 import Router from './router';
 
-export { Resource, GenericResource } from './generic';
-export { BaseResourceError, InvalidResponseCode, ValidationError, NetworkError } from './errors';
+export {
+    Resource,
+    Response,
+    GenericResource,
+} from './generic';
+
+export {
+    BaseResourceError,
+    InvalidResponseCode,
+    RequestValidationError,
+    NetworkError,
+} from './errors';
+
+export {
+    ValidationError,
+    SingleValidationError,
+    ListValidationError,
+    ValidationErrorInterface,
+    ParentValidationErrorInterface,
+    parseErrors,
+    prepareError,
+} from './validationError';
 
 
 export default Router;

--- a/src/response.js
+++ b/src/response.js
@@ -23,6 +23,11 @@ class ResponseWrapper {
     }
 
     /* istanbul ignore next */
+    get statusCode() { // eslint-disable-line class-methods-use-this
+        return this.status;
+    }
+
+    /* istanbul ignore next */
     get statusType() { // eslint-disable-line class-methods-use-this
         throw new Error('Not implemented');
     }

--- a/src/superagent/index.js
+++ b/src/superagent/index.js
@@ -1,3 +1,4 @@
 import { SuperAgentResource } from './resource';
 
+export { SuperagentResponse } from './resource';
 export default SuperAgentResource;

--- a/src/validationError.js
+++ b/src/validationError.js
@@ -1,0 +1,371 @@
+import { isArray, isString, isObject, hasValue } from './typeChecks';
+
+
+const ErrorIterator = function (instance) {
+    let curKey = 0;
+
+    return {
+        next() {
+            const nextVal = instance.errorByIndex(curKey);
+
+            // Note: If a custom error handler does not coerce undefined to null,
+            //  the iterator will stop too early
+            //
+            // Feel free to submit a PR if this annoys you!
+            if (nextVal === undefined) {
+                return { done: true };
+            } else {
+                curKey += 1;
+
+                return {
+                    value: nextVal,
+                };
+            }
+        },
+    };
+};
+
+const bindAndCoerce = (error, fieldName) => {
+    const res = error || null;
+
+    if (res !== null) {
+        res.bindToField(fieldName);
+    }
+
+    return res;
+};
+
+export class ValidationErrorInterface {
+    constructor(errors) {
+        // Store errors
+        this._errors = errors;
+    }
+
+    get errors() {
+        return this._errors;
+    }
+
+    // Support for .. of loops
+    [Symbol.iterator]() {
+        return ErrorIterator(this);
+    }
+
+    /**
+     * Iterator used for .forEach/.filter/.map
+     */
+    _iter() { // eslint-disable-line class-methods-use-this
+        return this._errors;
+    }
+
+    /**
+     * Used by firstError and iteration protocol
+     */
+    errorByIndex(index) { // eslint-disable-line class-methods-use-this
+        return this._errors[index];
+    }
+
+    /* istanbul ignore next: just an interface */
+    hasError() { // eslint-disable-line class-methods-use-this
+        return 'ValidationErrorInterface::asString is not implemented';
+    }
+
+    bindToField(fieldName) {
+        // istanbul ignore else: never false in tests
+        if (process.env.NODE_ENV !== 'production') {
+            if (this.fieldName && this.fieldName !== fieldName) {
+                // eslint-disable-next-line no-console
+                console.error(`ValidationErrorInterface: Unexpected rebind of ${this} as ${fieldName} (was ${this.fieldName})`);
+            }
+        }
+
+        this.fieldName = fieldName;
+    }
+
+    /* istanbul ignore next: just an interface */
+    asString() { // eslint-disable-line class-methods-use-this
+        return 'ValidationErrorInterface::asString is not implemented';
+    }
+
+    toString() {
+        return this.asString();
+    }
+
+    map(...rest) {
+        return this._iter().map(...rest);
+    }
+
+    forEach(...rest) {
+        return this._iter().forEach(...rest);
+    }
+
+    filter(...rest) {
+        return this._iter().filter(...rest);
+    }
+}
+
+export class SingleValidationError extends ValidationErrorInterface {
+    constructor(errors) {
+        // istanbul ignore else: never false in tests
+        if (process.env.NODE_ENV !== 'production') {
+            if (!isArray(errors) || errors.filter(x => !isString(x)).length > 0) {
+                // eslint-disable-next-line no-console
+                console.error('SingleValidationError: `errors` argument must be an array of strings');
+            }
+        }
+
+        super(errors);
+    }
+
+    hasError() {
+        return this._errors.length > 0;
+    }
+
+    asString(glue = ' ') {
+        return this._errors.join(glue || '');
+    }
+}
+
+export class ParentValidationErrorInterface extends ValidationErrorInterface {
+    // If null, there are no nonFieldErrors
+    //
+    // Some parent validation errors cannot have nonFieldErrors (e.g. ListValidationError,
+    //  since a list cannot have attributes in JSON). Helps keep things DRY, since the result
+    //  of getError & firstError won't change if nonFieldErrors is always null.
+    nonFieldErrors = null;
+
+    getError(fieldName, allowNonFields) {
+        if (this.errors[fieldName] || (allowNonFields && this.nonFieldErrors)) {
+            return this.errors[fieldName] || this.nonFieldErrors || null;
+        }
+
+        return null;
+    }
+
+    firstError(allowNonField) {
+        if (allowNonField && this.nonFieldErrors) {
+            return this.nonFieldErrors;
+        }
+
+        return this.errorByIndex(0) || null;
+    }
+}
+
+export class ListValidationError extends ParentValidationErrorInterface {
+    constructor(errors) {
+        // istanbul ignore else: never false in tests
+        if (process.env.NODE_ENV !== 'production') {
+            // Takes: anything thats not a ValidationError (besides null)
+            const filterFn = (x) => {
+                if (x === null) {
+                    return false;
+                }
+
+                return !x || !(x instanceof ValidationErrorInterface);
+            };
+
+            if (errors) {
+                if (!isArray(errors) || errors.filter(filterFn).length > 0) {
+                    /* eslint-disable no-console */
+                    console.error('ListValidationError: `errors argument` must be an array of ValidationErrorInterface? instances');
+                    console.error('    Supported Builtins: null/SingleValidationError/ListValidationError/ValidationError');
+                    /* eslint-enable no-console */
+                }
+            }
+        }
+
+        // MAP: falsy to null, bind all errors w/ their fieldName
+        super((errors || []).map(bindAndCoerce));
+    }
+
+    hasError() {
+        return this._errors
+            .filter(x => x && x.hasError && x.hasError()).length > 0;
+    }
+
+    asString(glue = '; ') {
+        return this._errors.map((value, key) => `${key}: ${value.asString()}`)
+                           .join(glue);
+    }
+}
+
+export class ValidationError extends ParentValidationErrorInterface {
+    constructor(errors, nonFieldErrors) {
+        // istanbul ignore else: never false in tests
+        if (process.env.NODE_ENV !== 'production') {
+            // Takes: anything thats not a ValidationError (besides null)
+            const filterFn = (key) => {
+                if (errors[key] === null) {
+                    return false;
+                }
+
+                return !errors[key] || !(errors[key] instanceof ValidationErrorInterface);
+            };
+
+            if (errors) {
+                if (!isObject(errors) || Object.keys(errors).filter(filterFn).length > 0) {
+                    /* eslint-disable no-console */
+                    console.error('ListValidationError: `errors argument` must be an object of ValidationErrorInterface? instances');
+                    console.error('    Supported Builtins: null/SingleValidationError/ListValidationError/ValidationError');
+                    /* eslint-enable no-console */
+                }
+            }
+        }
+
+        // MAP: falsy to null, bind all errors w/ their fieldName
+        const mutErrors = {};
+        Object.keys(errors || {}).forEach((fieldName) => {
+            mutErrors[fieldName] = bindAndCoerce(errors[fieldName], fieldName);
+        });
+
+        super(mutErrors);
+
+        // Bind nonFieldErrors
+        this.nonFieldErrors = nonFieldErrors || null;
+        if (this.nonFieldErrors) {
+            this.nonFieldErrors.bindToField('nonFieldErrors');
+        }
+
+        // store a list of keys (for iteration)
+        this._errKeys = Object.keys(this._errors);
+    }
+
+    hasError() {
+        return this._errKeys.length > 0;
+    }
+
+    asString(glue = '; ') {
+        let prefix = '';
+
+        if (this.nonFieldErrors) {
+            prefix = `${this.nonFieldErrors}${this._errKeys.length ? glue : ''}`;
+        }
+
+        return prefix + this._errKeys.map(k => `${k}: ${this._errors[k].asString()}`)
+                        .join(glue);
+    }
+
+    _iter() {
+        return Object.keys(this._errors).map(x => this.errors[x]);
+    }
+
+    errorByIndex(index) {
+        return this.errors[this._errKeys[index]];
+    }
+}
+
+/**
+ * Convert errorText (json or normal text) to a ValidationError
+ *
+ * @param {*} errorText
+ * @param {Object} parentConfig
+ */
+export function parseErrors(errorText, parentConfig) {
+    let error = null;
+
+    if (isString(errorText)) {
+        if (errorText) {
+            try {
+                error = JSON.parse(errorText);
+            } catch (e) {
+                // if json parsing fails, handle as text
+                error = errorText;
+            }
+        } else {
+            error = '';
+        }
+    } else {
+        error = errorText;
+    }
+
+    // force undefined to be a string
+    if (error === undefined) {
+        error = `${undefined}`;
+    }
+
+    const result = parentConfig.prepareError(error, parentConfig);
+
+    if (!result) {
+        return result;
+    }
+
+    // istanbul ignore else: can only happen w/ custom prepareError
+    if (result instanceof ValidationErrorInterface) {
+        return result.hasError() ? result : null;
+    }
+
+    // For anything else, just return the result (why would anyone do this though?)
+    // istanbul ignore next: can only happen w/ custom prepareError
+    return result;
+}
+
+/**
+ * Convert an error into a subclass of ValidationErrorInterface
+ *
+ * @param {*} err
+ * @param {Object} parentConfig
+ */
+export function prepareError(err, parentConfig) {
+    if (isString(err)) {
+        // Note: SingleValidationError contains a list of errors per field
+        return new SingleValidationError([err || '#$empty-message$#']);
+    }
+
+    else if (isArray(err)) {
+        // If the array contains only strings, turn it into a SingleValidationError
+        if (err.length > 0 && err.filter(x => isString(x)).length === err.length) {
+            return new SingleValidationError(err);
+        }
+
+        // Parse children of the error and continue
+        const errors = err.map(x => parentConfig.prepareError(x, parentConfig));
+
+        // Should be a nested error, turn it into ListValidationError
+        return new ListValidationError(errors);
+    }
+
+    else if (isObject(err)) {
+        const errors = typeof err.errors === 'undefined' ? err : err.errors;
+
+        let resNonField = null;
+        const resErrors = {};
+
+        Object.keys(errors).forEach((key) => {
+            const error = parentConfig.prepareError(errors[key], parentConfig);
+
+            if (key === 'non_field_errors') {
+                resNonField = error;
+            }
+
+            // note: we only add errors as fields if we can parse the field error (or need to)
+            else if (error !== null) {
+                resErrors[key] = error;
+            }
+        });
+
+        // if no errors ensure atleast a default message is set
+        if (Object.keys(resErrors).length === 0 && !resNonField) {
+            resNonField = new SingleValidationError([err || '#$empty-message$#']);
+        }
+
+        return new ValidationError(resErrors, resNonField);
+    }
+
+    // If undefined/null, lets turn it into a null
+    else if (!hasValue(err)) {
+        return null;
+    }
+
+    // Everything else gets turned into a string (bools, numbers, binary)
+    else {
+        // Note: Empty string means there is no error
+        err = `${err}`;
+
+        // istanbul ignore else: only custom classes w/ custom toString
+        if (err) {
+            return new SingleValidationError([err]);
+        }
+
+        // istanbul ignore next: only custom classes w/ custom toString
+        return null;
+    }
+}

--- a/test-server.js
+++ b/test-server.js
@@ -49,6 +49,12 @@ app.options('/options', (req, res) => {
     });
 });
 
+app.get('/error500', (req, res) => {
+    res.status(500).json({
+        message: 'yolo',
+    });
+});
+
 app.get('/cookies', (req, res) => {
     if (req.cookies.sessionid === 'secret') {
         res.status(200).json({

--- a/test/RequestValidationError.js
+++ b/test/RequestValidationError.js
@@ -1,0 +1,88 @@
+import { expect } from 'chai';
+
+import { RequestValidationError, ValidationError, ValidationErrorInterface } from '../src';
+
+let instance = null;
+
+const responseText = JSON.stringify({
+    errors: {
+        non_field_errors: [
+            'Something is generally broken',
+        ],
+
+        password: [
+            'too short',
+            'missing numbers',
+        ],
+
+        email: {
+            something: 'be wrong yo',
+        },
+
+        remember: false,
+    },
+});
+
+export default {
+    'RequestValidationError api': {
+        beforeEach() {
+            instance = new RequestValidationError(400, responseText);
+        },
+        'constructor works': () => {
+            // ResponseText can be empty
+            new RequestValidationError(400, '');
+
+            // ResponseText can be missing
+            new RequestValidationError(0, {});
+
+            // No args also works
+            new RequestValidationError();
+        },
+        'instance.statusCode is correct': () => {
+            expect(instance.statusCode).to.equal(400);
+        },
+        'instance.responseText is correct': () => {
+            expect(instance.responseText).to.equal(responseText);
+        },
+        'toString works': () => {
+            expect(instance.toString()).to.equal(`RequestValidationError 400: ${responseText}`);
+            expect(instance.toString()).to.equal(instance._message);
+        },
+        'isNetworkError is false': () => {
+            expect(instance.isNetworkError).to.equal(false);
+        },
+        'isInvalidResponseCode is false': () => {
+            expect(instance.isInvalidResponseCode).to.equal(false);
+        },
+        'isValidationError is true': () => {
+            expect(instance.isValidationError).to.equal(true);
+        },
+        'errors method returns a ValidationError': () => {
+            expect(instance.errors).to.be.an.instanceof(ValidationError);
+            expect(instance.errors).to.be.an.instanceof(ValidationErrorInterface);
+        },
+        'hasError is true': () => {
+            expect(instance.hasError).to.be.a('function');
+            expect(instance.hasError()).to.be.equal(true);
+        },
+        'ensures that empty errors are still errors': () => {
+            const toTest = [
+                // ResponseText can be empty
+                new RequestValidationError(400, ''),
+
+                // ResponseText can be undefined
+                new RequestValidationError(400, undefined),
+
+                // ResponseText can be false
+                new RequestValidationError(400, false),
+
+                // No args also works
+                new RequestValidationError(400),
+            ];
+
+            toTest.forEach((element, i) => {
+                expect(element.hasError()).to.be.equal(true, `index: ${i}`);
+            });
+        },
+    },
+};

--- a/test/ValidationError.js
+++ b/test/ValidationError.js
@@ -1,141 +1,603 @@
 import { expect } from 'chai';
+import { spy } from 'sinon';
 
-import { ValidationError } from '../src';
+import {
+    ValidationError,
+    ListValidationError,
+    SingleValidationError,
+    parseErrors,
+    prepareError,
+} from '../src';
 
-let instance = null;
 
-const responseBody = {
-    statusCode: 400,
-    responseText: JSON.stringify({
-        errors: {
-            // Converted to single string
-            non_field_errors: [
-                'Something is generally broken',
-            ],
+/**
+ * @param {*} error
+ * @param {Number | String?} strVal If defined compared against error.toString result
+ * @param {T?} type If null error must be null, else error must be instance of type
+ */
+const expectValidationError = (error, { strVal, type }) => {
+    if (type !== undefined) {
+        if (type === null) {
+            expect(error).to.be.equal(null);
+        } else {
+            expect(error).to.be.a.instanceof(type);
+        }
+    }
 
-            // Converted to a string joined by a comma
-            password: [
-                'too short',
-                'missing numbers',
-            ],
+    if (strVal !== undefined) {
+        expect(error.toString).to.be.a('function');
+        expect(error.toString()).to.be.equal(strVal);
+    }
+};
 
-            // JSON stringify is used
-            email: {
-                something: 'be wrong yo',
-            },
+const expectParentValidationError = (parent, fieldName, { toString, type, allowNonField }) => {
+    expect(parent.getError).to.be.a('function');
 
-            // Will be converted to a string
-            remember: false,
-        },
-    }),
+    expectValidationError(parent.getError(fieldName, allowNonField || false), { toString, type });
 };
 
 
+let instance;
+
 export default {
-    'ValidationError api': {
+    'String conversion': {
+        'SingleValidationError - simple': () => {
+            const a = new SingleValidationError(['bar']);
+
+            expect(a.asString()).to.equal('bar');
+            expect(a.toString()).to.equal(a.asString());
+            expect(`${a}`).to.equal(a.asString());
+        },
+        'SingleValidationError - asString glue': () => {
+            const b = new SingleValidationError(['i', 'have', 'issues...']);
+
+            expect(b.asString()).to.equal('i have issues...');
+            expect(b.toString()).to.equal(b.asString());
+            expect(`${b}`).to.equal(b.asString());
+
+            expect(b.asString('+')).to.equal('i+have+issues...');
+        },
+
+        'ListValidationError - simple': () => {
+            const f = new ListValidationError([
+                new SingleValidationError(['bar']),
+                new SingleValidationError(['swag', 'ded']),
+            ], new SingleValidationError(['am nonField error']));
+
+            expect(f.asString()).to.equal('0: bar; 1: swag ded');
+            expect(f.toString()).to.equal(f.asString());
+            expect(`${f}`).to.equal(f.asString());
+        },
+
+        'ListValidationError - asString glue': () => {
+            const f = new ListValidationError([
+                new SingleValidationError(['bar']),
+                new SingleValidationError(['swag', 'ded']),
+            ], new SingleValidationError(['am nonField error']));
+
+            expect(f.asString('+')).to.equal('0: bar+1: swag ded');
+        },
+
+        'ValidationError - simple': () => {
+            const f = new ValidationError({
+                foo: new SingleValidationError(['bar']),
+                yolo: new SingleValidationError(['swag', 'ded']),
+            }, new SingleValidationError(['am nonField error']));
+
+            expect(f.asString()).to.equal('am nonField error; foo: bar; yolo: swag ded');
+            expect(f.toString()).to.equal(f.asString());
+            expect(`${f}`).to.equal(f.asString());
+        },
+
+        'ValidationError - w/o nonFields': () => {
+            const f = new ValidationError({
+                foo: new SingleValidationError(['bar']),
+                yolo: new SingleValidationError(['swag', 'ded']),
+            }, null);
+
+            expect(f.asString()).to.equal('foo: bar; yolo: swag ded');
+            expect(f.toString()).to.equal(f.asString());
+            expect(`${f}`).to.equal(f.asString());
+        },
+
+        'ValidationError - asString glue': () => {
+            const f = new ValidationError({
+                foo: new SingleValidationError(['bar']),
+                yolo: new SingleValidationError(['swag', 'ded']),
+            }, new SingleValidationError(['am nonField error']));
+
+            expect(f.asString('+')).to.equal('am nonField error+foo: bar+yolo: swag ded');
+        },
+    },
+
+    'ValidationError helper methods': {
         beforeEach() {
-            instance = new ValidationError(responseBody);
+            instance = new ValidationError({
+                password: new SingleValidationError([
+                    'too short.',
+                    'missing numbers.',
+                ]),
+                email: new ValidationError({
+                    something: new SingleValidationError([
+                        'be wrong yo',
+                    ]),
+                }),
+                remember: new SingleValidationError([
+                    'false',
+                ]),
+                deliveryAddress: new ListValidationError([
+                    new ValidationError(null, new SingleValidationError([
+                        'Provided address is not supported',
+                    ])),
+                    null,
+                    new ValidationError({
+                        zip: new SingleValidationError([
+                            'Please enter a valid address',
+                        ]),
+                        country: new SingleValidationError([
+                            'This field is required.',
+                            'Please select a valid country.',
+                        ]),
+                    }),
+                    null,
+                    null,
+                    null,
+                ]),
+            }, new SingleValidationError(['Something is generally broken']));
         },
 
-        'constructor works': () => {
-            // ResponseText can be empty
-            new ValidationError({ responseText: '' });
-
-            // ResponseText can be mising
-            new ValidationError({});
-
-            // No args also works
-            new ValidationError();
-        },
-        'instance.statusCode is correct': () => {
-            expect(instance.statusCode).to.equal(400);
-        },
-        'instance.responseText is correct': () => {
-            expect(instance.responseText).to.equal(responseBody.responseText);
-        },
-        'toString works': () => {
-            expect(instance.toString()).to.equal(`ValidationError 400: ${responseBody.responseText}`);
-            expect(instance.toString()).to.equal(instance._message);
-        },
-        'isNetworkError is false': () => {
-            expect(instance.isNetworkError).to.equal(false);
-        },
-        'isInvalidResponseCode is false': () => {
-            expect(instance.isInvalidResponseCode).to.equal(false);
-        },
-        'isValidationError is true': () => {
-            expect(instance.isValidationError).to.equal(true);
-        },
-        'errors are normalized correctly': () => {
-            expect(instance.nonFieldErrors).to.equal('Something is generally broken');
-            expect(instance.errors).to.be.a('object');
-
-            expect(instance.errors.password).to.be.equal('too short, missing numbers');
-            expect(instance.errors.remember).to.be.equal('false');
-
-            // Nested ValidationError objects
-            expect(instance.errors.email).to.be.a.instanceof(ValidationError);
-            expect(instance.errors.email.errors.something).to.be.equal('be wrong yo');
-        },
-        'getFieldError has been removed': () => {
-            expect(instance.getFieldError).to.be.a('undefined');
-        },
         'getError works': () => {
-            expect(instance.getError).to.be.a('function');
-
-            expect(instance.getError('password')).to.be.equal('too short, missing numbers');
-            expect(instance.getError('remember')).to.be.equal('false');
-
-            // Nested ValidationError objects
-            expect(instance.getError('email')).to.be.a.instanceof(ValidationError);
-            expect(instance.getError('email').getError).to.be.a('function');
-            expect(instance.getError('email').getError('something')).to.be.equal('be wrong yo');
-
-            // with allowNonField it should return nonFieldError (if no field specific errors exist)
-            expect(instance.getError('random-field')).to.be.a('null');
-            expect(instance.getError('random-field', true)).to.be.equal('Something is generally broken');
-            expect(instance.getError('password', true)).to.be.equal('too short, missing numbers');
-
-            // If no errors it should return null
-            const noErr = new ValidationError({
-                responseText: '{}',
+            expectParentValidationError(instance, 'password', {
+                strVal: 'too short. missing numbers.',
+                type: SingleValidationError,
             });
 
+            expectParentValidationError(instance, 'remember', {
+                strVal: 'false',
+                type: SingleValidationError,
+            });
+        },
+
+        'nested getError works': () => {
+            expectParentValidationError(instance, 'email', {
+                type: ValidationError,
+            });
+
+            expectParentValidationError(instance.getError('email'), 'something', {
+                strVal: 'be wrong yo',
+                type: SingleValidationError,
+            });
+        },
+
+        'ListValidationError getError works': () => {
+            expectParentValidationError(instance, 'deliveryAddress', {
+                type: ListValidationError,
+            });
+
+            expectParentValidationError(instance.getError('deliveryAddress'), 0, {
+                strVal: 'Provided address is not supported',
+                type: ValidationError,
+            });
+            expectParentValidationError(instance.getError('deliveryAddress'), 1, {
+                type: null,
+            });
+            expectParentValidationError(instance.getError('deliveryAddress'), 2, {
+                strVal: 'zip: Please enter a valid address; country: This field is required. Please select a valid country.',
+                type: ValidationError,
+            });
+            expectParentValidationError(instance.getError('deliveryAddress'), 3, {
+                type: null,
+            });
+            expectParentValidationError(instance.getError('deliveryAddress'), 4, {
+                type: null,
+            });
+            expectParentValidationError(instance.getError('deliveryAddress'), 5, {
+                type: null,
+            });
+            expectParentValidationError(instance.getError('deliveryAddress'), 99, {
+                type: null,
+            });
+        },
+        'getError - allowNonField flag': () => {
+            // getError for a non-existing field w/o allowNonField, should give us null
+            expectParentValidationError(instance, 'random-field', {
+                type: null,
+                allowNonField: false,
+            });
+
+            // getError for a non-existing field with allowNonField, should give us nonFieldErrors
+            expectParentValidationError(instance, 'random-field', {
+                strVal: 'Something is generally broken',
+                type: SingleValidationError,
+                allowNonField: true,
+            });
+
+            // getError for an existing field with allowNonField, should give us the field
+            expectParentValidationError(instance, 'password', {
+                strVal: 'too short. missing numbers.',
+                type: SingleValidationError,
+                allowNonField: true,
+            });
+
+            // If no errors it should return null
+            const noErr = new ValidationError();
+            expect(noErr.nonFieldErrors).to.be.a('null');
             expect(noErr.getError('foo')).to.be.a('null');
             expect(noErr.getError('foo', true)).to.be.a('null');
         },
-        'firstError works': () => {
+        'ValidationError firstError works': () => {
             expect(instance.firstError).to.be.a('function');
 
-            // First error without allowNonField should be the password error
-            expect(instance.firstError()).to.be.equal('too short, missing numbers');
+            // firstError w/o allowNonField, should give us `password`
+            expectValidationError(instance.firstError(), {
+                strVal: 'too short. missing numbers.',
+                type: SingleValidationError,
+                fieldName: 'password',
+            });
 
-            // First error with allowNonField should be the nonFieldError
-            expect(instance.firstError(true)).to.be.equal('Something is generally broken');
+            // firstError with allowNonField, should give us `nonFieldErrors`
+            expectValidationError(instance.firstError(true), {
+                strVal: 'Something is generally broken',
+                type: SingleValidationError,
+                fieldName: 'nonFieldErrors',
+            });
 
-            // First error with allowNonField without non_field_errors should be a field error
-            expect(new ValidationError({
-                responseText: JSON.stringify({
-                    errors: {
-                        foo: ['bar', 'baz'],
+            // If no errors it should return null (w/ and w/o allowNonField)
+            const noErr = new ValidationError();
+            expect(noErr.firstError()).to.be.a('null');
+            expect(noErr.firstError(true)).to.be.a('null');
+        },
+        'ListValidationError firstError works': () => {
+            expectParentValidationError(instance, 'deliveryAddress', {
+                type: ListValidationError,
+            });
+
+            const dError = instance.getError('deliveryAddress');
+            expect(dError.firstError).to.be.a('function');
+
+            // Result must be the same for both
+            [true, false].forEach((allowNonField) => {
+                expectValidationError(dError.firstError(allowNonField), {
+                    strVal: 'Provided address is not supported',
+                    type: ValidationError,
+                    fieldName: 0,
+                });
+            });
+
+            // If no errors it should return null (w/ and w/o allowNonField)
+            const noErr = new ListValidationError([]);
+            expect(noErr.firstError()).to.be.a('null');
+            expect(noErr.firstError(true)).to.be.a('null');
+        },
+    },
+
+    'iteration api': {
+        'ListValidationError - spread': () => {
+            const err1 = new SingleValidationError(['bar']);
+            const err2 = new SingleValidationError(['swag', 'ded']);
+
+            const f = new ListValidationError([
+                err1,
+                err2,
+            ]);
+
+            expect([...f]).to.deep.equal([
+                err1,
+                err2,
+            ]);
+        },
+
+        'ListValidationError - for .. of': () => {
+            const err1 = new SingleValidationError(['bar']);
+            const err2 = new SingleValidationError(['swag', 'ded']);
+            const err3 = new SingleValidationError(['last']);
+
+            const f = new ListValidationError([
+                err1,
+                err2,
+                err3,
+            ]);
+
+            const expected = [
+                'bar',
+                'swag ded',
+                'last',
+            ];
+
+            /* eslint-disable no-restricted-syntax */
+            for (const error of f) {
+                expect(error.fieldName).to.not.equal(undefined);
+                expect(expected[error.fieldName]).to.not.equal(undefined);
+
+                // access via f.errors
+                expect(`${f.errors[error.fieldName]}`).to.equal(expected[error.fieldName]);
+
+                // access via f.getError()
+                expect(`${f.getError(error.fieldName)}`).to.equal(expected[error.fieldName]);
+            }
+
+            // Checks that we can break the for .. of loop
+            for (const x of f) {
+                expect(x).to.equal(err1);
+                break;
+            }
+            /* eslint-enable no-restricted-syntax */
+        },
+
+        'ValidationError - spread': () => {
+            const err1 = new SingleValidationError(['bar']);
+            const err2 = new SingleValidationError(['swag', 'ded']);
+
+            const f = new ValidationError({
+                err1,
+                err2,
+            }, new SingleValidationError(['am nonField error']));
+
+            expect([...f]).to.deep.equal([
+                err1,
+                err2,
+            ]);
+        },
+
+        'ValidationError - for .. of': () => {
+            const err1 = new SingleValidationError(['bar']);
+            const err2 = new SingleValidationError(['swag', 'ded']);
+
+            const f = new ValidationError({
+                foo: err1,
+                yolo: err2,
+            }, new SingleValidationError(['am nonField error']));
+
+            const expected = {
+                foo: 'bar',
+                yolo: 'swag ded',
+            };
+
+            /* eslint-disable no-restricted-syntax */
+            for (const error of f) {
+                expect(error.fieldName).to.not.equal(undefined);
+                expect(expected[error.fieldName]).to.not.equal(undefined);
+
+                // tostring is correct
+                expect(`${error}`).to.equal(expected[error.fieldName]);
+
+                // access via f.errors
+                expect(`${f.errors[error.fieldName]}`).to.equal(expected[error.fieldName]);
+
+                // access via f.getError()
+                expect(`${f.getError(error.fieldName)}`).to.equal(expected[error.fieldName]);
+            }
+
+            // Checks that we can break the for .. of loop
+            for (const x of f) {
+                expect(x).to.equal(err1);
+                break;
+            }
+            /* eslint-enable no-restricted-syntax */
+        },
+
+        'SingleValidationError - map': () => {
+            const f = new SingleValidationError(['bar', 'baz']);
+
+            const spyFn = spy();
+            f.map(spyFn);
+
+            expect(spyFn.calledWith('bar', 0)).to.be.equal(true);
+            expect(spyFn.calledWith('baz', 1)).to.be.equal(true);
+        },
+
+        'ListValidationError - map': () => {
+            const err1 = new SingleValidationError(['bar']);
+            const err2 = new SingleValidationError(['swag', 'ded']);
+
+            const f = new ListValidationError([err1, err2]);
+
+            const spyFn = spy();
+            f.map(spyFn);
+
+            expect(spyFn.calledWith(err1, 0)).to.be.equal(true);
+            expect(spyFn.calledWith(err2, 1)).to.be.equal(true);
+        },
+
+        'ValidationError - map': () => {
+            const err1 = new SingleValidationError(['bar']);
+            const err2 = new SingleValidationError(['swag', 'ded']);
+            const nonFieldErr = new SingleValidationError(['am nonField error']);
+
+            const f = new ValidationError({ err1, err2 }, nonFieldErr);
+
+            const spyFn = spy();
+            f.map(spyFn);
+
+            expect(spyFn.calledWith(err1, 0)).to.be.equal(true);
+            expect(spyFn.calledWith(err2, 1)).to.be.equal(true);
+        },
+
+        'SingleValidationError - forEach': () => {
+            const f = new SingleValidationError(['bar', 'baz']);
+
+            const spyFn = spy();
+            f.forEach(spyFn);
+
+            expect(spyFn.calledWith('bar', 0)).to.be.equal(true);
+            expect(spyFn.calledWith('baz', 1)).to.be.equal(true);
+        },
+
+        'ListValidationError - forEach': () => {
+            const err1 = new SingleValidationError(['bar']);
+            const err2 = new SingleValidationError(['swag', 'ded']);
+
+            const f = new ListValidationError([err1, err2]);
+
+            const spyFn = spy();
+            f.forEach(spyFn);
+
+            expect(spyFn.calledWith(err1, 0)).to.be.equal(true);
+            expect(spyFn.calledWith(err2, 1)).to.be.equal(true);
+        },
+
+        'ValidationError - forEach': () => {
+            const err1 = new SingleValidationError(['bar']);
+            const err2 = new SingleValidationError(['swag', 'ded']);
+            const nonFieldErr = new SingleValidationError(['am nonField error']);
+
+            const f = new ValidationError({ err1, err2 }, nonFieldErr);
+
+            const spyFn = spy();
+            f.forEach(spyFn);
+
+            expect(spyFn.calledWith(err1, 0)).to.be.equal(true);
+            expect(spyFn.calledWith(err2, 1)).to.be.equal(true);
+        },
+
+        'SingleValidationError - filter': () => {
+            const f = new SingleValidationError(['bar', 'baz']);
+
+            const spyFn = spy(() => false);
+            const res = f.filter(spyFn);
+
+            expect(spyFn.calledWith('bar', 0)).to.be.equal(true);
+            expect(spyFn.calledWith('baz', 1)).to.be.equal(true);
+            expect(res).to.be.deep.equal([]);
+        },
+
+        'ListValidationError - filter': () => {
+            const err1 = new SingleValidationError(['bar']);
+            const err2 = new SingleValidationError(['swag', 'ded']);
+
+            const f = new ListValidationError([err1, err2]);
+
+            const spyFn = spy(() => false);
+            const res = f.filter(spyFn);
+
+            expect(spyFn.calledWith(err1, 0)).to.be.equal(true);
+            expect(spyFn.calledWith(err2, 1)).to.be.equal(true);
+            expect(res).to.be.deep.equal([]);
+        },
+
+        'ValidationError - filter': () => {
+            const err1 = new SingleValidationError(['bar']);
+            const err2 = new SingleValidationError(['swag', 'ded']);
+            const nonFieldErr = new SingleValidationError(['am nonField error']);
+
+            const f = new ValidationError({ err1, err2 }, nonFieldErr);
+
+            const spyFn = spy(() => false);
+            const res = f.filter(spyFn);
+
+            expect(spyFn.calledWith(err1, 0)).to.be.equal(true);
+            expect(spyFn.calledWith(err2, 1)).to.be.equal(true);
+            expect(res).to.be.deep.equal([]);
+        },
+    },
+
+    // FIXME: separate this test to units
+    'parseErrors api -': {
+        beforeEach() {
+            const text = JSON.stringify({
+                errors: {
+                    non_field_errors: [
+                        'Something is generally broken',
+                    ],
+
+                    password: [
+                        'too short',
+                        'missing numbers.',
+                    ],
+
+                    remember: false,
+
+                    email: {
+                        something: 'be wrong yo',
+                        stripped: null,
                     },
-                }),
-            }).firstError(true)).to.be.equal('bar, baz');
 
-            // If non_field_errors is an empty array, we want to be sure we don't handle it as an error
-            expect(new ValidationError({
-                responseText: JSON.stringify({
-                    errors: {
-                        non_field_errors: [],
-                        foo: ['bar', 'baz'],
-                    },
-                }),
-            }).firstError(true)).to.be.equal('bar, baz');
+                    deliveryAddress: [
+                        {
+                            non_field_errors: [
+                                'Provided address is not supported',
+                            ],
+                        },
+                        null, // kept as null
+                        '', // Replaced w/ special #$empty-message$#
+                        {
+                            zip: [
+                                'Please enter a valid address',
+                            ],
+                            country: [
+                                'This field is required.',
+                                'Please select a valid country.',
+                            ],
+                        },
+                    ],
 
-            // If no errors it should return null
-            expect(new ValidationError({
-                responseText: '{}',
-            }).firstError()).to.be.a('null');
+                    coercesToNonField: {},
+                },
+            });
+
+            instance = parseErrors(text, {
+                parseErrors,
+                prepareError,
+            });
+        },
+        'parser conforms to contracts': () => {
+            // based on the input the result should be of ValidationError type
+            expect(instance).to.be.an.instanceof(ValidationError);
+
+            expectParentValidationError(instance, undefined, {
+                strVal: 'Something is generally broken',
+                type: SingleValidationError,
+                allowNonField: true,
+            });
+
+            expectParentValidationError(instance, 'password', {
+                strVal: 'too short. missing numbers.',
+                type: SingleValidationError,
+            });
+
+            expectParentValidationError(instance, 'remember', {
+                strVal: 'false',
+                type: SingleValidationError,
+            });
+
+            expectParentValidationError(instance, 'email', {
+                type: ValidationError,
+            });
+            expectParentValidationError(instance.getError('email'), 'something', {
+                strVal: 'be wrong yo',
+                type: SingleValidationError,
+            });
+            expectParentValidationError(instance.getError('email'), 'stripped', {
+                type: null,
+            });
+
+            expectParentValidationError(instance, 'deliveryAddress', {
+                type: ListValidationError,
+            });
+
+            expectParentValidationError(instance.getError('deliveryAddress'), 0, {
+                strVal: 'Provided address is not supported',
+                type: ValidationError,
+            });
+
+            expectParentValidationError(instance.getError('deliveryAddress'), 1, {
+                type: null,
+            });
+
+            expectParentValidationError(instance.getError('deliveryAddress'), 2, {
+                type: SingleValidationError,
+                strVal: '#$empty-message$#',
+            });
+
+            expectParentValidationError(instance.getError('deliveryAddress'), 3, {
+                strVal: 'zip: Please enter a valid address; country: This field is required. Please select a valid country.',
+                type: ValidationError,
+            });
+
+            expectParentValidationError(instance, 'coercesToNonField', {
+                strVal: '#$empty-message$#',
+                type: ValidationError,
+            });
         },
     },
 };

--- a/test/exports.js
+++ b/test/exports.js
@@ -10,11 +10,16 @@ export default {
             expect(tgResources.GenericResource).to.be.a('function', 'GenericResource is exported');
             expect(tgResources.BaseResourceError).to.be.a('function', 'BaseResourceError is exported');
             expect(tgResources.InvalidResponseCode).to.be.a('function', 'InvalidResponseCode is exported');
-            expect(tgResources.ValidationError).to.be.a('function', 'ValidationError is exported');
+            expect(tgResources.RequestValidationError).to.be.a('function', 'RequestValidationError is exported');
             expect(tgResources.NetworkError).to.be.a('function', 'NetworkError is exported');
 
-            expect(tgResources.getConfig).to.be.a('undefined', 'getConfig is not exported');
-            expect(tgResources.setConfig).to.be.a('undefined', 'setConfig is not exported');
+            expect(tgResources.ValidationError).to.be.a('function', 'ValidationError is exported');
+            expect(tgResources.ListValidationError).to.be.a('function', 'ListValidationError is exported');
+            expect(tgResources.SingleValidationError).to.be.a('function', 'SingleValidationError is exported');
+            expect(tgResources.ValidationErrorInterface).to.be.a('function', 'ValidationErrorInterface is exported');
+            expect(tgResources.ParentValidationErrorInterface).to.be.a('function', 'ParentValidationErrorInterface is exported');
+
+            expect(tgResources.Response).to.be.a('function', 'Response is exported');
         },
     },
     'correct subclassing': {
@@ -24,14 +29,35 @@ export default {
         'InvalidResponseCode is subclass of BaseResourceError': () => {
             assert(isSubClass(tgResources.InvalidResponseCode, tgResources.BaseResourceError), 'its not');
         },
-        'ValidationError is subclass of InvalidResponseCode': () => {
-            assert(isSubClass(tgResources.ValidationError, tgResources.BaseResourceError), 'its not');
+        'RequestValidationError is subclass of InvalidResponseCode': () => {
+            assert(isSubClass(tgResources.RequestValidationError, tgResources.InvalidResponseCode), 'its not');
         },
-        'ValidationError is subclass of BaseResourceError': () => {
-            assert(isSubClass(tgResources.ValidationError, tgResources.BaseResourceError), 'its not');
+        'RequestValidationError is subclass of BaseResourceError': () => {
+            assert(isSubClass(tgResources.RequestValidationError, tgResources.BaseResourceError), 'its not');
         },
         'NetworkError is subclass of BaseResourceError': () => {
-            assert(isSubClass(tgResources.ValidationError, tgResources.BaseResourceError), 'its not');
+            assert(isSubClass(tgResources.NetworkError, tgResources.BaseResourceError), 'its not');
+        },
+        'ValidationError is a separate class': () => {
+            assert(!isSubClass(tgResources.ValidationError, tgResources.BaseResourceError), 'its not');
+            assert(!isSubClass(tgResources.ValidationError, tgResources.InvalidResponseCode), 'its not');
+            assert(!isSubClass(tgResources.ValidationError, tgResources.RequestValidationError), 'its not');
+            assert(!isSubClass(tgResources.ValidationError, tgResources.NetworkError), 'its not');
+        },
+        'ValidationError is subclass of ValidationErrorInterface': () => {
+            assert(isSubClass(tgResources.ValidationError, tgResources.ValidationErrorInterface), 'its not');
+        },
+        'ValidationError is subclass of ParentValidationErrorInterface': () => {
+            assert(isSubClass(tgResources.ValidationError, tgResources.ParentValidationErrorInterface), 'its not');
+        },
+        'SingleValidationError is subclass of ValidationErrorInterface': () => {
+            assert(isSubClass(tgResources.SingleValidationError, tgResources.ValidationErrorInterface), 'its not');
+        },
+        'ListValidationError is subclass of ValidationErrorInterface': () => {
+            assert(isSubClass(tgResources.ListValidationError, tgResources.ValidationErrorInterface), 'its not');
+        },
+        'ListValidationError is subclass of ParentValidationErrorInterface': () => {
+            assert(isSubClass(tgResources.ListValidationError, tgResources.ParentValidationErrorInterface), 'its not');
         },
     },
 };


### PR DESCRIPTION
- added new configuration option mutateRawResponse
- added type annotations to mutateResponse/mutateError
- Split ValidationError to RequestValidationError and ValidationError
- Added ListValidationError for parsing errors related to lists of objects
- Added SingleValidationError for errors of a single field
- Simplified call signature of parseErrors/prepareError
- We now export default parseErrors
- We now export default prepareError
- ValidationErrorInterface: support `for .. of` syntax
- ValidationErrorInterface: support iteration protocol
- Tons of new tests