### PR TITLE
Add `setConfig` to Router/Resource

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tg-resources",
-  "version": "2.0.0-alpha.7",
+  "version": "2.0.0-alpha.8",
   "description": "Abstractions on-top of `superagent` (or other Ajax libaries) for communication with REST.",
   "main": "./dist/index.js",
   "jsnext:main": "./es/index.js",

--- a/src/base.js
+++ b/src/base.js
@@ -48,6 +48,21 @@ class GenericResource {
         return this._config;
     }
 
+    setConfig(config) {
+        // Update _customConfig
+        this._customConfig = {
+            ...this._customConfig,
+            ...config || {},
+        };
+
+        // Reset _config so it is recreated in the next call to .config
+        this.clearConfigCache();
+    }
+
+    clearConfigCache() {
+        this._config = null;
+    }
+
     mutateRawResponse(rawResponse, requestConfig) {
         const config = this.config(requestConfig);
         if (isFunction(config.mutateRawResponse)) {

--- a/src/router.js
+++ b/src/router.js
@@ -13,6 +13,8 @@ class Router {
 
         const defaultRoutes = this.defaultRoutes || this.constructor.defaultRoutes;
 
+        this._childKeys = [];
+
         if (defaultRoutes) {
             bindResources(defaultRoutes, this);
         }
@@ -61,6 +63,25 @@ class Router {
         }
 
         return this._config;
+    }
+
+    setConfig(config) {
+        // Update _customConfig
+        this._customConfig = {
+            ...this._customConfig,
+            ...config || {},
+        };
+
+        // Reset _config so it is recreated in the next call to .config
+        this.clearConfigCache();
+    }
+
+    clearConfigCache() {
+        this._config = null;
+
+        this._childKeys.forEach((key) => {
+            this[key].clearConfigCache();
+        });
     }
 }
 

--- a/src/util.js
+++ b/src/util.js
@@ -33,6 +33,9 @@ export function bindResources(routes, $this) {
         res[routeName]._setParent($this);
     });
 
+    const keyMap = $this._childKeys.concat(Object.keys(res));
+    res._childKeys = keyMap;
+
     try {
         Object.assign($this, res);
     } catch (e) {

--- a/test/router.js
+++ b/test/router.js
@@ -1166,5 +1166,105 @@ export default {
             expect(sdk.config()).to.be.an('object');
             expect(sdk.config().apiRoot).to.be.equal('some/root');
         },
+
+        'setConfig works': () => {
+            class SDK extends Router {
+                static defaultConfig = {
+                    apiRoot: 'some/root',
+                    defaultAcceptHeader: 'fake/mime',
+                };
+
+                static defaultRoutes = {
+                    me: new Resource('user/me'),
+                };
+            }
+
+
+            const sdk = new SDK(null, {
+                headers: {
+                    from: 'resource',
+                },
+            });
+
+            // Check config values
+            expect(sdk.config()).to.be.an('object');
+            expect(sdk.config().apiRoot).to.be.equal('some/root');
+            expect(sdk.config().defaultAcceptHeader).to.be.equal('fake/mime');
+            expect(sdk.config().headers).to.deep.equal({
+                from: 'resource',
+            });
+            expect(sdk.me.config()).to.be.an('object');
+            expect(sdk.me.config().apiRoot).to.be.equal(sdk.config().apiRoot);
+            expect(sdk.me.config().headers).to.deep.equal(sdk.config().headers);
+            expect(sdk.me.config().defaultAcceptHeader).to.be.equal(sdk.config().defaultAcceptHeader);
+
+            // Update config via setConfig w/ no value
+            sdk.setConfig(null);
+
+            // _config should be nulled
+            expect(sdk._config).to.be.null; // eslint-disable-line no-unused-expressions
+
+            // Check config values again
+            expect(sdk.config()).to.be.an('object');
+            expect(sdk._config).to.not.be.null; // eslint-disable-line no-unused-expressions
+            expect(sdk.config().apiRoot).to.be.equal('some/root');
+            expect(sdk.config().defaultAcceptHeader).to.be.equal('fake/mime');
+            expect(sdk.config().headers).to.deep.equal({
+                from: 'resource',
+            });
+            expect(sdk.me.config()).to.be.an('object');
+            expect(sdk.me.config().apiRoot).to.be.equal(sdk.config().apiRoot);
+            expect(sdk.me.config().headers).to.deep.equal(sdk.config().headers);
+            expect(sdk.me.config().defaultAcceptHeader).to.be.equal(sdk.config().defaultAcceptHeader);
+
+            // Update config via setConfig
+            sdk.setConfig({
+                apiRoot: 'foo',
+                headers: {
+                    via: 'setConfig',
+                },
+            });
+
+            // _config should be nulled
+            expect(sdk._config).to.be.null; // eslint-disable-line no-unused-expressions
+
+            // Check config values again
+            expect(sdk.config()).to.be.an('object');
+            expect(sdk._config).to.not.be.null; // eslint-disable-line no-unused-expressions
+            expect(sdk.config().apiRoot).to.be.equal('foo');
+            expect(sdk.config().defaultAcceptHeader).to.be.equal('fake/mime');
+            expect(sdk.config().headers).to.deep.equal({
+                via: 'setConfig',
+            });
+            expect(sdk.me.config()).to.be.an('object');
+            expect(sdk.me.config().apiRoot).to.be.equal(sdk.config().apiRoot);
+            expect(sdk.me.config().headers).to.deep.equal(sdk.config().headers);
+            expect(sdk.me.config().defaultAcceptHeader).to.be.equal(sdk.config().defaultAcceptHeader);
+
+            // Call setConfig on the resource
+            sdk.me.setConfig({
+                headers: {
+                    via: 'route setConfig',
+                },
+            });
+
+            // route level _config should be nulled
+            expect(sdk.me._config).to.be.null; // eslint-disable-line no-unused-expressions
+
+            // but sdk level config should not
+            expect(sdk._config).to.not.be.null; // eslint-disable-line no-unused-expressions
+
+            // Check config values again
+            expect(sdk.me.config()).to.be.an('object');
+            expect(sdk.me.config().headers).to.deep.equal({
+                via: 'route setConfig',
+            });
+
+            // sdk level config should not be affected
+            expect(sdk.config()).to.be.an('object');
+            expect(sdk.config().headers).to.deep.equal({
+                via: 'setConfig',
+            });
+        },
     },
 };


### PR DESCRIPTION
This method allows one to overwrite router/resource config at runtime. As a result of this
the node level `_customConfig` is updated and internal config cache is cleared. The internal
config cache clearing also clears cache of any descendants (for routers).

Also added `clearConfigCache()` which clears config cache of the node and all its descendants.