### PR TITLE
Add support for attachments to post/put/patch/del

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tg-resources",
-  "version": "2.0.0-alpha.9",
+  "version": "2.0.0-alpha.10",
   "description": "Abstractions on-top of `superagent` (or other Ajax libaries) for communication with REST.",
   "main": "./dist/index.js",
   "jsnext:main": "./es/index.js",
@@ -67,6 +67,7 @@
     "isparta": "*",
     "lodash.template": "*",
     "mocha": "^3.4.2",
+    "multiparty": "*",
     "nyc": "^11.0.3",
     "rimraf": "*",
     "sinon": "^2.3.8",

--- a/src/single.js
+++ b/src/single.js
@@ -13,24 +13,24 @@ export default function makeSingle(baseClass) {
             return this.fetch(kwargs, query, requestConfig, 'options');
         }
 
-        post(kwargs, data, query, requestConfig = null, /* istanbul ignore next: https://github.com/istanbuljs/babel-plugin-istanbul/issues/94 */ method = 'post') {
+        post(kwargs, data, query, attachments, requestConfig = null, /* istanbul ignore next: https://github.com/istanbuljs/babel-plugin-istanbul/issues/94 */ method = 'post') {
             const thePath = this.buildThePath(kwargs, requestConfig);
 
             return this.handleRequest(
-                this.createRequest(method, thePath, query, data || {}, requestConfig), requestConfig,
+                this.createRequest(method, thePath, query, data || {}, attachments, requestConfig), requestConfig,
             );
         }
 
-        patch(kwargs, data, query, requestConfig = null) {
-            return this.post(kwargs, data, query, requestConfig, 'patch');
+        patch(kwargs, data, query, attachments, requestConfig = null) {
+            return this.post(kwargs, data, query, attachments, requestConfig, 'patch');
         }
 
-        put(kwargs, data, query, requestConfig = null) {
-            return this.post(kwargs, data, query, requestConfig, 'put');
+        put(kwargs, data, query, attachments, requestConfig = null) {
+            return this.post(kwargs, data, query, attachments, requestConfig, 'put');
         }
 
-        del(kwargs, data, query, requestConfig = null) {
-            return this.post(kwargs, data, query, requestConfig, 'del');
+        del(kwargs, data, query, attachments, requestConfig = null) {
+            return this.post(kwargs, data, query, attachments, requestConfig, 'del');
         }
     }
 

--- a/src/superagent/resource.js
+++ b/src/superagent/resource.js
@@ -2,6 +2,7 @@ import request from 'superagent';
 
 import ResponseWrapper from '../response';
 import GenericResource from '../base';
+import { isArray, isObject } from '../typeChecks';
 
 
 export class SuperagentResponse extends ResponseWrapper {
@@ -41,7 +42,7 @@ export class SuperAgentResource extends GenericResource {
         return new SuperagentResponse(response, error && error.status === undefined ? error : null);
     }
 
-    createRequest(method, url, query, data, requestConfig) { // eslint-disable-line class-methods-use-this
+    createRequest(method, url, query, data, attachments, requestConfig) { // eslint-disable-line class-methods-use-this
         method = method.toLowerCase();
 
         let req = request[method](url);
@@ -54,7 +55,34 @@ export class SuperAgentResource extends GenericResource {
             req = req.query(query);
         }
 
-        if (data) {
+        // If attachments are used construct a multipart request
+        if (attachments) {
+            attachments.forEach((attachment) => {
+                req = req.attach(attachment.field, attachment.file, attachment.name);
+            });
+
+            // Set all the fields
+            Object.keys(data).forEach((fieldKey) => {
+                const value = data[fieldKey];
+
+                // Future: Make this logic configurable
+                if (value !== null && value !== undefined) {
+                    if (isArray(value)) {
+                        // Send arrays as multipart arrays
+                        value.forEach((fValue) => {
+                            req = req.field(`${fieldKey}[]`, fValue);
+                        });
+                    } else if (isObject(value)) {
+                        // Posting objects as field contents is not supported by superagent
+                        //  to work around this we just jsonify them
+                        req = req.field(fieldKey, JSON.stringify(value));
+                    } else {
+                        // Convert values via their toString
+                        req = req.field(fieldKey, `${value}`);
+                    }
+                }
+            });
+        } else {
             req = req.send(data);
         }
 

--- a/test/functional.js
+++ b/test/functional.js
@@ -1,7 +1,7 @@
 import { assert, expect } from 'chai';
 import { spy } from 'sinon';
 
-import listen from '../test-server';
+import listen, { expectedBuffer, hostUrl } from '../test-server';
 
 import { Resource, Response, RequestValidationError } from '../src';
 import { isSubClass } from '../src/typeChecks';
@@ -68,7 +68,7 @@ export default {
 
         'fetch `/` works': (done) => {
             const res = new Resource('/', {
-                apiRoot: 'http://127.0.0.1:3000',
+                apiRoot: hostUrl,
                 defaultAcceptHeader: 'text/html',
             });
 
@@ -77,7 +77,7 @@ export default {
 
         'fetch `/` works w/ manual Accept header': (done) => {
             const res = new Resource('/', {
-                apiRoot: 'http://127.0.0.1:3000',
+                apiRoot: hostUrl,
                 headers: {
                     Accept: 'text/html',
                 },
@@ -88,7 +88,7 @@ export default {
 
         'fetch `/` is HTML even if Accept header is not explicitly set': (done) => {
             const res = new Resource('/', {
-                apiRoot: 'http://127.0.0.1:3000',
+                apiRoot: hostUrl,
             });
 
             expectResponse(res.fetch(), 'home', done);
@@ -98,7 +98,7 @@ export default {
             const spyFn = spy();
 
             const res = new Resource('/hello', {
-                apiRoot: 'http://127.0.0.1:3000',
+                apiRoot: hostUrl,
                 mutateResponse: spyFn,
             });
 
@@ -114,7 +114,7 @@ export default {
 
         'mutateResponse functionally works': (done) => {
             const res = new Resource('/hello', {
-                apiRoot: 'http://127.0.0.1:3000',
+                apiRoot: hostUrl,
                 mutateResponse(data, raw) {
                     return {
                         data,
@@ -135,7 +135,7 @@ export default {
             const spyFn = spy();
 
             const res = new Resource('/error500', {
-                apiRoot: 'http://127.0.0.1:3000',
+                apiRoot: hostUrl,
                 mutateError: spyFn,
             });
 
@@ -151,7 +151,7 @@ export default {
 
         'mutateError functionally works': (done) => {
             const res = new Resource('/error500', {
-                apiRoot: 'http://127.0.0.1:3000',
+                apiRoot: hostUrl,
                 mutateError(error, rawResponse, resource) {
                     return [
                         'the error', // put a string here so comparison is easy
@@ -196,7 +196,7 @@ export default {
             }));
 
             const res = new Resource('/hello', {
-                apiRoot: 'http://127.0.0.1:3000',
+                apiRoot: hostUrl,
                 mutateRawResponse: spyFn,
             });
 
@@ -215,7 +215,7 @@ export default {
 
         'fetch `/hello` works': (done) => {
             const res = new Resource('/hello', {
-                apiRoot: 'http://127.0.0.1:3000',
+                apiRoot: hostUrl,
             });
 
             expectResponse(res.fetch(), {
@@ -225,7 +225,7 @@ export default {
 
         'headers work as object': (done) => {
             const res = new Resource('/headers', {
-                apiRoot: 'http://127.0.0.1:3000',
+                apiRoot: hostUrl,
                 headers: { auth: 'foo' },
             });
 
@@ -236,7 +236,7 @@ export default {
 
         'headers work as function': (done) => {
             const res = new Resource('/headers', {
-                apiRoot: 'http://127.0.0.1:3000',
+                apiRoot: hostUrl,
                 headers: () => ({ auth: 'foo' }),
             });
 
@@ -247,7 +247,7 @@ export default {
 
         'cookies work as object': (done) => {
             const res = new Resource('/cookies', {
-                apiRoot: 'http://127.0.0.1:3000',
+                apiRoot: hostUrl,
                 cookies: { sessionid: 'secret' },
             });
 
@@ -258,7 +258,7 @@ export default {
 
         'cookies work as function': (done) => {
             const res = new Resource('/cookies', {
-                apiRoot: 'http://127.0.0.1:3000',
+                apiRoot: hostUrl,
                 cookies: () => ({ sessionid: 'secret' }),
             });
 
@@ -269,7 +269,7 @@ export default {
 
         'kwargs work': (done) => {
             const res = new Resource('/dogs/${pk}', {
-                apiRoot: 'http://127.0.0.1:3000',
+                apiRoot: hostUrl,
             });
 
             expectResponse(res.fetch({ pk: '26fe9717-e494-43eb-b6d0-0c77422948a2' }), {
@@ -285,7 +285,7 @@ export default {
 
         'head request works': (done) => {
             const res = new Resource('/hello', {
-                apiRoot: 'http://127.0.0.1:3000',
+                apiRoot: hostUrl,
             });
 
             expectResponse(res.head(), {}, done);
@@ -293,7 +293,7 @@ export default {
 
         'options request works': (done) => {
             const res = new Resource('/options', {
-                apiRoot: 'http://127.0.0.1:3000',
+                apiRoot: hostUrl,
             });
 
             expectResponse(res.options(), {
@@ -303,7 +303,7 @@ export default {
 
         'del request works': (done) => {
             const res = new Resource('/dogs/${pk}', {
-                apiRoot: 'http://127.0.0.1:3000',
+                apiRoot: hostUrl,
             });
 
             expectResponse(res.del({ pk: 'f2d8f2a6-7b68-4f81-8e47-787e4260b815' }), { deleted: true }, () => {
@@ -315,10 +315,10 @@ export default {
 
         'put request works': (done) => {
             const listRes = new Resource('/dogs/', {
-                apiRoot: 'http://127.0.0.1:3000',
+                apiRoot: hostUrl,
             });
             const detailRes = new Resource('/dogs/${pk}', {
-                apiRoot: 'http://127.0.0.1:3000',
+                apiRoot: hostUrl,
             });
 
             listRes.put(null, { name: 'Rex' }).then((data) => {
@@ -333,7 +333,7 @@ export default {
 
         'patch request works': (done) => {
             const res = new Resource('/dogs/${pk}', {
-                apiRoot: 'http://127.0.0.1:3000',
+                apiRoot: hostUrl,
             });
 
             const params = { pk: '26fe9717-e494-43eb-b6d0-0c77422948a2' };
@@ -347,18 +347,20 @@ export default {
         },
 
         'statusValidationError is handled properly': (done) => {
-            const res = new Resource('/error400', {
-                apiRoot: 'http://127.0.0.1:3000',
+            const res = new Resource('/error413', {
+                apiRoot: hostUrl,
             });
 
-            res.post(null, { name: '' }).then(() => {
+            res.post(null, { name: '' }, undefined, undefined, {
+                statusValidationError: [400, 413],
+            }).then(() => {
                 done(new Error('Expected request to fail'));
             }, (err) => {
                 // the error must RequestValidationError
                 expect(err).to.be.an.instanceof(RequestValidationError);
 
                 // statusCode must be correct
-                expect(err.statusCode).to.equal(400);
+                expect(err.statusCode).to.equal(413);
 
                 // hasError must be true
                 expect(err.hasError()).to.be.equal(true);
@@ -373,7 +375,7 @@ export default {
 
         'statusValidationError is handled properly - nonField only': (done) => {
             const res = new Resource('/error400_nonField', {
-                apiRoot: 'http://127.0.0.1:3000',
+                apiRoot: hostUrl,
             });
 
             res.fetch(null).then(() => {
@@ -394,6 +396,53 @@ export default {
                 // all good
                 done();
             }).catch(done);
+        },
+
+        'attachments work': (done) => {
+            const res = new Resource('/attachments', {
+                apiRoot: hostUrl,
+            });
+
+            const postData = {
+                name: 'foo',
+                ignored0: null,
+                ignored1: undefined,
+                bool0: false,
+                bool1: true,
+                array: [
+                    'first!',
+                    'first! E: missed it',
+                ],
+                object: {
+                    foo: 1,
+                    bar: 0,
+                },
+            };
+
+            const attachments = [
+                {
+                    field: 'text',
+                    file: expectedBuffer,
+                    name: 'dummy.txt',
+                },
+            ];
+
+            res.post(null, postData, null, attachments).then((response) => {
+                expect(response).to.deep.equal({
+                    name: 'foo',
+                    text: {
+                        name: 'dummy.txt',
+                        size: expectedBuffer.length,
+                    },
+                    bool0: 'false',
+                    bool1: 'true',
+                    array: postData.array,
+                    object: JSON.stringify(postData.object),
+                });
+
+                // all good
+                done();
+            }, done);
         },
     },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1470,6 +1470,12 @@ fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
+fd-slicer@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.0.1.tgz#8b5bcbd9ec327c5041bf9ab023fd6750f1177e65"
+  dependencies:
+    pend "~1.2.0"
+
 figures@^1.3.5:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
@@ -2539,6 +2545,13 @@ ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
+multiparty@*:
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/multiparty/-/multiparty-4.1.4.tgz#4c96dcbdc11e3f7917e1615e640b4b5022be64fd"
+  dependencies:
+    fd-slicer "~1.0.1"
+    safe-buffer "5.1.2"
+
 mute-stream@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.5.tgz#8fbfabb0a98a253d3184331f9e8deb7372fac6c0"
@@ -2836,6 +2849,10 @@ path-type@^2.0.0:
 pathval@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
+
+pend@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
 
 performance-now@^0.2.0:
   version "0.2.0"
@@ -3208,6 +3225,10 @@ run-async@^0.1.0:
 rx-lite@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
+
+safe-buffer@5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
 
 safe-buffer@^5.0.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"


### PR DESCRIPTION
- **Warning:** Signature for post/put/patch/del has changed:
  - `method(kwargs, data, query, requestConfig = null)` -> `method(kwargs, data, query, attachments, requestConfig = null)`
  - Where attachments is: `Array<Attachment { field: string, file: Blob/File, name: string }>`
- If attachments are used the data will be submitted as multipart
  - Fields containing arrays are converted to multipart arrays:
    - `{ foo: ['bar', 'baz'] }` -> `foo[] = 'bar', foo[] = 'baz'`
  - Fields containing an object will be jsonified
- Added tests for attachments and multipart requests