### PR TITLE
Bugfix: fetch createRequest attachments

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tg-resources",
-  "version": "2.0.0-alpha.10",
+  "version": "2.0.0-alpha.11",
   "description": "Abstractions on-top of `superagent` (or other Ajax libaries) for communication with REST.",
   "main": "./dist/index.js",
   "jsnext:main": "./es/index.js",

--- a/src/single.js
+++ b/src/single.js
@@ -2,7 +2,7 @@ export default function makeSingle(baseClass) {
     class SingleObjectResource extends baseClass {
         fetch(kwargs, query, requestConfig = null, method = 'get') {
             const thePath = this.buildThePath(kwargs, requestConfig);
-            return this.handleRequest(this.createRequest(method, thePath, query, null, requestConfig), requestConfig);
+            return this.handleRequest(this.createRequest(method, thePath, query, null, null, requestConfig), requestConfig);
         }
 
         head(kwargs, query, requestConfig = null) {


### PR DESCRIPTION
PR #27 added support for for multipart forms and attachments. To achieve this
we changed the signature for createRequest. However the change was not done
inside fetch method. As a result fetch did not work properly if requestConfig was used.

Future: We should add functional tests that use requestConfig so we capture bugs like these earlier