### PR TITLE
Fix requests without content failing

### DIFF
--- a/packages/saga-router/test/SagaResource.test.ts
+++ b/packages/saga-router/test/SagaResource.test.ts
@@ -131,7 +131,7 @@ describe('createSagaRouter functional', () => {
 
         await expectResponse(store.runSaga(api.dogs.details.del(
             params, null, null, null, { onRequestError: onError },
-        )), { deleted: true }, store);
+        )), null, store);
 
         try {
             await store.runSaga(api.dogs.details.fetch(params)).toPromise();
@@ -140,7 +140,7 @@ describe('createSagaRouter functional', () => {
             expect(err.statusCode).toEqual(404);
         }
 
-        expect(store.getState()).toEqual({ deleted: true });
+        expect(store.getState()).toEqual(null);
     });
 
     test('statusValidationError is handled properly', async () => {
@@ -208,7 +208,7 @@ describe('createSagaRouter functional', () => {
 
         await expectResponse(
             store.runSagaInitialized(api.dogs.details.del(params, null, null, null, requestConfig)),
-            { deleted: true }, store,
+            null, store,
         );
 
         try {
@@ -220,7 +220,7 @@ describe('createSagaRouter functional', () => {
             expect(onError.mock.calls.length).toEqual(1);
         }
 
-        expect(store.getState()).toEqual({ deleted: true });
+        expect(store.getState()).toEqual(null);
 
         try {
             await store.runSagaInitialized(api.dogs.details.del(params, null, null, null, requestConfig)).toPromise();

--- a/packages/test-server/src/test-server.ts
+++ b/packages/test-server/src/test-server.ts
@@ -167,10 +167,8 @@ function configureServer(logger: boolean = false) {
 
         if (dogIndex !== -1) {
             allDogs.splice(dogIndex, 1);
-
-            res.status(200).json({
-                deleted: true,
-            });
+            res.removeHeader('Content-Type');
+            res.status(204).end();
         } else {
             res.status(404).json({
                 message: 'object does not exist',

--- a/packages/tg-resources-fetch/test/functional-fetch.test.ts
+++ b/packages/tg-resources-fetch/test/functional-fetch.test.ts
@@ -330,7 +330,7 @@ describe('Resource basic requests work', () => {
             apiRoot: hostUrl,
         });
 
-        await expectResponse(res.del({ pk: 'f2d8f2a6-7b68-4f81-8e47-787e4260b815' }), { deleted: true });
+        await expectResponse(res.del({ pk: 'f2d8f2a6-7b68-4f81-8e47-787e4260b815' }), null);
         await expectError(res.fetch({ pk: 'f2d8f2a6-7b68-4f81-8e47-787e4260b815' }), { statusCode: 404 });
     });
 

--- a/packages/tg-resources-superagent/test/functional-superagent.test.ts
+++ b/packages/tg-resources-superagent/test/functional-superagent.test.ts
@@ -326,7 +326,7 @@ describe('Resource basic requests work', () => {
             apiRoot: hostUrl,
         });
 
-        await expectResponse(res.del({ pk: 'f2d8f2a6-7b68-4f81-8e47-787e4260b815' }), { deleted: true });
+        await expectResponse(res.del({ pk: 'f2d8f2a6-7b68-4f81-8e47-787e4260b815' }), null);
         await expectError(res.fetch({ pk: 'f2d8f2a6-7b68-4f81-8e47-787e4260b815' }), { statusCode: 404 });
     });
 


### PR DESCRIPTION
Django responds with HTTP 204 NO CONTENT response to delete queries, and those responses have no content type, causing `@tg-resources/fetch` to react with an error.