### PR TITLE
Fix AbortSignal issue in Safari

### DIFF
--- a/packages/is/src/index.ts
+++ b/packages/is/src/index.ts
@@ -41,11 +41,17 @@ export const isStatusCode = (statusCodes: number | number[], status: any): statu
 
 export const isAbortSignal = (signal: any): signal is AbortSignal => {
     const proto = (
-        signal
+        !!signal
         && typeof signal === 'object'
         && Object.getPrototypeOf(signal)
     );
-    return !!(proto && proto.constructor.name === 'AbortSignal');
+    // Fail-safe fallback, is required to work with some browsers that do not have native implementation of AbortSignal
+    const isCompatible = (
+        !!signal
+        && typeof signal.aborted !== 'undefined'
+        && typeof signal.onabort !== 'undefined'
+    );
+    return !!(proto && proto.constructor.name === 'AbortSignal') || isCompatible;
 };
 
 

--- a/packages/is/test/typeChecks.test.ts
+++ b/packages/is/test/typeChecks.test.ts
@@ -213,5 +213,6 @@ describe('typeChecks api', () => {
 
         }
         expect(isAbortSignal(new AbortSignal())).toEqual(true);
+        expect(isAbortSignal({ aborted: false, onabort: null, listeners: {} })).toEqual(true);
     });
 });


### PR DESCRIPTION
Fall back to checking the used properties of the signal if the name
of the class is not AbortSignal to determine if it is usable as
abort signal. This is necessary to correctly recognized polyfilled
abort signals.