### PR TITLE
Use text as the default content type for fetch backend

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,7 +10,7 @@ jobs:
     if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/master')
     strategy:
       matrix:
-        node: [10, 12, 14]
+        node: [12, 14, 16]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ Using NPM
 ```sh
 npm i tg-resources
 
-# And resource backend
-npm i @tg-resources/superagent
-
 # Or
 npm i @tg-resources/fetch
+
+# And resource backend
+npm i @tg-resources/superagent
 ```
 
 Or using Yarn
@@ -29,11 +29,11 @@ Or using Yarn
 ```sh
 yarn add tg-resources
 
-# And resource backend
-yarn add @tg-resources/superagent
-
 # Or
 yarn add @tg-resources/fetch
+
+# And resource backend
+yarn add @tg-resources/superagent
 ```
 
 ### Does it work on react native?
@@ -52,7 +52,7 @@ import 'abortcontroller-polyfill/dist/polyfill-patch-fetch'
 
 ```js
 import { Router } from "tg-resources"
-import { SuperAgentResource: Resource } from "@tg-resources/superagent"
+import { FetchResource: Resource } from "@tg-resources/fetch"
 
 const onLoad = result => console.log(result);
 const onError = result => console.error(result);

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ Using NPM
 ```sh
 npm i tg-resources
 
-# Or
+# And add fetch backend
 npm i @tg-resources/fetch
 
-# And resource backend
+# Or use superagent backend
 npm i @tg-resources/superagent
 ```
 
@@ -29,10 +29,10 @@ Or using Yarn
 ```sh
 yarn add tg-resources
 
-# Or
+# And fetch backend
 yarn add @tg-resources/fetch
 
-# And resource backend
+# Or use superagent backend
 yarn add @tg-resources/superagent
 ```
 

--- a/packages/tg-resources-fetch/src/resource.ts
+++ b/packages/tg-resources-fetch/src/resource.ts
@@ -137,13 +137,10 @@ function parseFetchResponse(
             text: response.status === 204 ? null : '{}',
         });
     }
-    if (!response.headers.has('content-type')) {
-        // istanbul ignore next: Only happens w/ custom server that does not set Content-Type
-        throw new Error('Content type is missing from request');
-    }
 
     // Get content string to use correct parser
-    const contentType: string = response.headers.get('content-type') as string;
+    const contentType: string = (response.headers.get('content-type') ||
+        'text/plain') as string;
 
     if (contentType.includes('application/json')) {
         return response.json().then((body: any) => ({


### PR DESCRIPTION
Previously the fetch backend always raised an error when content type header was missing. Now it will default
to text content instead.